### PR TITLE
Fix bug where a panic would happen

### DIFF
--- a/main.go
+++ b/main.go
@@ -402,6 +402,9 @@ func (d *Dialer) GetFolders() (folders []string, err error) {
 		if b := bytes.IndexByte(line, '\n'); b != -1 {
 			folders = append(folders, string(line[b+1:]))
 		} else {
+			if len(line) == 0 {
+				return
+			}
 			i := len(line) - 1
 			quoted := line[i] == '"'
 			delim := byte(' ')


### PR DESCRIPTION
Hey, I just went ahead and got rid of this bug. The stacktrace is as follows.

```
panic: runtime error: index out of range [-1]

goroutine 140 [running]:
github.com/BrianLeishman/go-imap.(*Dialer).GetFolders.func1({0xf1f858, 0xf1f858, 0x0})
C:/Users/Administrator/go/pkg/mod/github.com/!brian!leishman/go-imap@v0.0.0-20211018214722-a869de640791/main.go:406 +0x305
```