### PR TITLE
Fix bug where the dialer can be null

### DIFF
--- a/main.go
+++ b/main.go
@@ -215,7 +215,7 @@ func New(username string, password string, host string, port int) (d *Dialer, er
 	if err != nil {
 		if Verbose {
 			log(connNum, "", aurora.Red(aurora.Bold("failed to establish connection")))
-			if d.conn != nil {
+			if d != nil && d.conn != nil {
 				d.conn.Close()
 			}
 		}


### PR DESCRIPTION
This PR fixes the bug where the dialer can be null if the tls connection fails for whatever reason and the verbose flag is set to true.

Saw this while testing my Go code.
```
github.com/BrianLeishman/go-imap.New({0xc0009f4500, 0x1a}, {0xc0009f4520, 0xa}, {0xc000a66450, 0xe}, 0x3e1)
        C:/Users/Anik/go/pkg/mod/github.com/!brian!leishman/go-imap@v0.1.3/main.go:218 +0x3aa
```