### PR TITLE
feature/idle: add idle implementation

### DIFF
--- a/idle.go
+++ b/idle.go
@@ -1,0 +1,27 @@
+package imap
+
+type ExistsEvent struct {
+	MessageIndex int
+}
+
+type ExpungeEvent struct {
+	MessageIndex int
+}
+
+type FetchEvent struct {
+	MessageIndex int
+	UID          uint32
+	Flags        []string
+}
+
+type IdleHandler struct {
+	OnExists  func(event ExistsEvent)
+	OnExpunge func(event ExpungeEvent)
+	OnFetch   func(event FetchEvent)
+}
+
+const (
+	IdleEventExists  = "EXISTS"
+	IdleEventExpunge = "EXPUNGE"
+	IdleEventFetch   = "FETCH"
+)


### PR DESCRIPTION
IDLE implementation added.

See RFC [from here](https://datatracker.ietf.org/doc/html/rfc2177)

Example code:

```go
package main

import (
	"fmt"

	"github.com/BrianLeishman/go-imap"
)

func main() {
	imap.Verbose = true
	im, err := imap.New("<REPLACE_ME>", "<REPLACE_ME>", "imap.gmail.com", 993)
	if err != nil {
		panic(err)
	}
	err = im.SelectFolder("INBOX")
	if err != nil {
		panic(err)
	}
	err = im.StartIdle(&imap.IdleHandler{
		OnExists: func(event imap.ExistsEvent) {
			fmt.Println("New email indx:", event.MessageIndex)
		},
		OnExpunge: func(event imap.ExpungeEvent) {
			fmt.Println("Deleted message:", event.MessageIndex)
		},
		OnFetch: func(event imap.FetchEvent) {
			fmt.Println("Fetched message:", event.MessageIndex)
			fmt.Println("UID:", event.UID)
			fmt.Println("Flags:", event.Flags)
		},
	})
	if err != nil {
		panic(err)
	}
	select {}
}

```