### PR TITLE
set and remove flags of mails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 imap
 imap.exe
+.devcontainer

--- a/main.go
+++ b/main.go
@@ -698,6 +698,25 @@ func (d *Dialer) MoveEmail(uid int, folder string) (err error) {
 	return nil
 }
 
+// mark an emai as seen
+func (d *Dialer) MarkSeen(uid int) (err error) {
+	True := true
+	flags := Flags{
+		Seen: &True,
+	}
+
+	readOnlyState := d.ReadOnly
+	if readOnlyState {
+		d.SelectFolder(d.Folder)
+	}
+	err = d.SetFlags(uid, flags)
+	if readOnlyState {
+		d.ExamineFolder(d.Folder)
+	}
+
+	return
+}
+
 // set system-flags and keywords
 func (d *Dialer) SetFlags(uid int, flags Flags) (err error) {
 	// craft the flags-string


### PR DESCRIPTION
Add two methods:
- `func (d *Dialer) SetFlags(uid int, flags Flags) (err error)` sets and removes system-flags and keywords
- `func (d *Dialer) MarkSeen(uid int) (err error)` shortcut for `(d *Dialer) SetFlags` to only set the Seen-flag