### PR TITLE
Implement delete/expunge and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,20 @@ func main() {
 		if len(emails) != 0 {
 			// Should print a summary of one of the the emails
 			// (yes, I said "one of", don't expect the emails to be returned in any particular order)
-			fmt.Print(emails[0])
+                       fmt.Print(emails[0])
 
-			im.MoveEmail(emails[0].UID, "INBOX/My Folder")
-			// Subject: FW: FW:  FW:  New Order
-			// To: Brian Leishman <brian@stumpyinc.com>
-			// From: Customer Service <sales@totallylegitdomain.com>
-			// Text: Hello, World!...(4.3 kB)
-			// HTML: <html xmlns:v="urn:s... (35 kB)
-			// 1 Attachment(s): [20180330174029.jpg (192 kB)]
-		}
+                       im.MoveEmail(emails[0].UID, "INBOX/My Folder")
+                       // Subject: FW: FW:  FW:  New Order
+                       // To: Brian Leishman <brian@stumpyinc.com>
+                       // From: Customer Service <sales@totallylegitdomain.com>
+                       // Text: Hello, World!...(4.3 kB)
+                       // HTML: <html xmlns:v="urn:s... (35 kB)
+                       // 1 Attachment(s): [20180330174029.jpg (192 kB)]
+
+                       // Mark the message as deleted then expunge it
+                       im.DeleteEmail(emails[0].UID)
+                       im.Expunge()
+               }
 
 	}
 

--- a/main.go
+++ b/main.go
@@ -799,6 +799,37 @@ func (d *Dialer) MarkSeen(uid int) (err error) {
 	return
 }
 
+// DeleteEmail marks an email as deleted
+func (d *Dialer) DeleteEmail(uid int) (err error) {
+	flags := Flags{
+		Deleted: FlagAdd,
+	}
+
+	readOnlyState := d.ReadOnly
+	if readOnlyState {
+		d.SelectFolder(d.Folder)
+	}
+	err = d.SetFlags(uid, flags)
+	if readOnlyState {
+		d.ExamineFolder(d.Folder)
+	}
+
+	return
+}
+
+// Expunge permanently removes messages marked as deleted in the current folder
+func (d *Dialer) Expunge() (err error) {
+	readOnlyState := d.ReadOnly
+	if readOnlyState {
+		d.SelectFolder(d.Folder)
+	}
+	_, err = d.Exec("EXPUNGE", false, RetryCount, nil)
+	if readOnlyState {
+		d.ExamineFolder(d.Folder)
+	}
+	return
+}
+
 // set system-flags and keywords
 func (d *Dialer) SetFlags(uid int, flags Flags) (err error) {
 	// craft the flags-string


### PR DESCRIPTION
## Summary
- add `DeleteEmail` and `Expunge` methods to mark messages as deleted and permanently remove them
- document deleting messages and expunging in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f76491838832fb0ece5b784234e89