### PR TITLE
Add SkipTLSVerification option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ func main() {
 	// If a retried function fails, the connection will be closed, then the program sleeps for an increasing amount of time,
 	// creates a new connection instance internally, selects the same folder, and retries the failed command(s).
 	// You can check out github.com/StirlingMarketingGroup/go-retry for the retry implementation being used
-	imap.RetryCount = 3
+        imap.RetryCount = 3
+
+        // Allow connecting to servers with self-signed certificates.
+        // Use with caution as this disables TLS verification.
+        imap.SkipTLSVerification = true
 
 	// Create a new instance of the IMAP connection you want to use
 	im, err := imap.New("username", "password", "mail.server.com", 993)

--- a/main.go
+++ b/main.go
@@ -40,6 +40,11 @@ var SkipResponses = false
 // RetryCount is the number of times retired functions get retried
 var RetryCount = 10
 
+// SkipTLSVerification disables certificate verification when establishing TLS
+// connections. This should be used with caution as it makes connections
+// susceptible to man-in-the-middle attacks.
+var SkipTLSVerification = false
+
 var lastResp string
 
 // Dialer is basically an IMAP connection
@@ -210,7 +215,11 @@ func NewWithOAuth2(username string, accessToken string, host string, port int) (
 			log(connNum, "", aurora.Green(aurora.Bold("establishing connection")))
 		}
 		var conn *tls.Conn
-		conn, err = tls.Dial("tcp", host+":"+strconv.Itoa(port), nil)
+		var tlsConf *tls.Config
+		if SkipTLSVerification {
+			tlsConf = &tls.Config{InsecureSkipVerify: true}
+		}
+		conn, err = tls.Dial("tcp", host+":"+strconv.Itoa(port), tlsConf)
 		if err != nil {
 			if Verbose {
 				log(connNum, "", aurora.Red(aurora.Bold(fmt.Sprintf("failed to connect: %s", err))))
@@ -270,7 +279,11 @@ func New(username string, password string, host string, port int) (d *Dialer, er
 			log(connNum, "", aurora.Green(aurora.Bold("establishing connection")))
 		}
 		var conn *tls.Conn
-		conn, err = tls.Dial("tcp", host+":"+strconv.Itoa(port), nil)
+		var tlsConf *tls.Config
+		if SkipTLSVerification {
+			tlsConf = &tls.Config{InsecureSkipVerify: true}
+		}
+		conn, err = tls.Dial("tcp", host+":"+strconv.Itoa(port), tlsConf)
 		if err != nil {
 			if Verbose {
 				log(connNum, "", aurora.Red(aurora.Bold(fmt.Sprintf("failed to connect: %s", err))))

--- a/main.go
+++ b/main.go
@@ -45,6 +45,13 @@ var RetryCount = 10
 // susceptible to man-in-the-middle attacks.
 var SkipTLSVerification = false
 
+func tlsConfig() *tls.Config {
+	if SkipTLSVerification {
+		return &tls.Config{InsecureSkipVerify: true}
+	}
+	return nil
+}
+
 var lastResp string
 
 // Dialer is basically an IMAP connection
@@ -215,10 +222,7 @@ func NewWithOAuth2(username string, accessToken string, host string, port int) (
 			log(connNum, "", aurora.Green(aurora.Bold("establishing connection")))
 		}
 		var conn *tls.Conn
-		var tlsConf *tls.Config
-		if SkipTLSVerification {
-			tlsConf = &tls.Config{InsecureSkipVerify: true}
-		}
+		tlsConf := tlsConfig()
 		conn, err = tls.Dial("tcp", host+":"+strconv.Itoa(port), tlsConf)
 		if err != nil {
 			if Verbose {
@@ -279,10 +283,7 @@ func New(username string, password string, host string, port int) (d *Dialer, er
 			log(connNum, "", aurora.Green(aurora.Bold("establishing connection")))
 		}
 		var conn *tls.Conn
-		var tlsConf *tls.Config
-		if SkipTLSVerification {
-			tlsConf = &tls.Config{InsecureSkipVerify: true}
-		}
+		tlsConf := tlsConfig()
 		conn, err = tls.Dial("tcp", host+":"+strconv.Itoa(port), tlsConf)
 		if err != nil {
 			if Verbose {


### PR DESCRIPTION
fix https://github.com/BrianLeishman/go-imap/issues/9

## Summary
- add `SkipTLSVerification` to optionally bypass TLS certificate validation
- document the option in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f7661cb6c832f9d251397681bf6c4