### PR TITLE
Add TLSSkipVerify flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ func main() {
 	// If a retried function fails, the connection will be closed, then the program sleeps for an increasing amount of time,
 	// creates a new connection instance internally, selects the same folder, and retries the failed command(s).
 	// You can check out github.com/StirlingMarketingGroup/go-retry for the retry implementation being used
-	imap.RetryCount = 3
+        imap.RetryCount = 3
+
+        // Use TLSSkipVerify if you need to connect to a server with a self-signed
+        // certificate. Skipping verification can expose you to man-in-the-middle
+        // attacks, so enable only when you trust the server.
+        imap.TLSSkipVerify = true
 
 	// Create a new instance of the IMAP connection you want to use
 	im, err := imap.New("username", "password", "mail.server.com", 993)

--- a/main.go
+++ b/main.go
@@ -50,6 +50,11 @@ var DialTimeout time.Duration
 // Zero means no timeout.
 var CommandTimeout time.Duration
 
+// TLSSkipVerify disables certificate verification when establishing new
+// connections. Use with caution; skipping verification exposes the
+// connection to man-in-the-middle attacks.
+var TLSSkipVerify bool
+
 var lastResp string
 
 // Dialer is basically an IMAP connection
@@ -207,7 +212,11 @@ func log(connNum int, folder string, msg interface{}) {
 
 func dialHost(host string, port int) (*tls.Conn, error) {
 	dialer := &net.Dialer{Timeout: DialTimeout}
-	return tls.DialWithDialer(dialer, "tcp", host+":"+strconv.Itoa(port), nil)
+	var cfg *tls.Config
+	if TLSSkipVerify {
+		cfg = &tls.Config{InsecureSkipVerify: true}
+	}
+	return tls.DialWithDialer(dialer, "tcp", host+":"+strconv.Itoa(port), cfg)
 }
 
 // NewWithOAuth2 makes a new imap with OAuth2


### PR DESCRIPTION
## Summary
- allow skipping TLS verification via `TLSSkipVerify`
- document new variable in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f9c03854c832f9e662e1f7eefbe74