### PR TITLE
Fix parseFetchTokens depth handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -1351,8 +1351,7 @@ func parseFetchTokens(r string) ([]*Token, error) {
 	tokenStart := 0
 	tokenEnd := 0
 	depth := 0
-	container := make([]tokenContainer, 4)
-	container[0] = &tokens
+	container := []tokenContainer{&tokens}
 
 	pushToken := func() *Token {
 		var t *Token
@@ -1458,6 +1457,9 @@ func parseFetchTokens(r string) ([]*Token, error) {
 				currentToken = TContainer
 				t := pushToken()
 				depth++
+				if depth >= len(container) {
+					container = append(container, nil)
+				}
 				container[depth] = &t.Tokens
 			case b == ')':
 				depth--

--- a/main_test.go
+++ b/main_test.go
@@ -173,3 +173,11 @@ func TestEnvelopeAtomAddress(t *testing.T) {
 		t.Fatalf("got %q want %q", addr, name)
 	}
 }
+
+func TestParseFetchTokensDeepNesting(t *testing.T) {
+	r := "UID 1 FOO (BAR (BAZ (QUX (QUUX))))"
+	_, err := parseFetchTokens(r)
+	if err != nil {
+		t.Fatalf("parseFetchTokens error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- handle nested parentheses without panicking in `parseFetchTokens`
- add regression test for deep nesting

## Testing
- `go vet ./...`
- `go test ./... -race -coverprofile=coverage.out`
- `golangci-lint run --timeout 3m` *(fails: errcheck, staticcheck issues pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_684acd105258832f95750dc5f01ba262