### PR TITLE
Allow a different tag generator

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -17,7 +17,13 @@ import (
 func (d *Dialer) Exec(command string, buildResponse bool, retryCount int, processLine func(line []byte) error) (response string, err error) {
 	var resp strings.Builder
 	err = retry.Retry(func() (err error) {
-		tag := []byte(fmt.Sprintf("%X", xid.New()))
+		var tag []byte
+
+		if Tagger != nil {
+			tag = []byte(Tagger())
+		} else {
+			tag = []byte(fmt.Sprintf("%X", xid.New()))
+		}
 
 		if CommandTimeout != 0 {
 			_ = d.conn.SetDeadline(time.Now().Add(CommandTimeout))

--- a/vars.go
+++ b/vars.go
@@ -33,3 +33,9 @@ var CommandTimeout time.Duration
 var TLSSkipVerify bool
 
 var lastResp string
+
+// Tagger is a function that returns a string which we can use as our tag
+// instead of the hexified XIDs in the default code.  This is necessary
+// to get through OpenResty's IMAP proxy (max 32 characters) and may be
+// helpful in debugging situations giving more control over tag format.
+var Tagger func() string


### PR DESCRIPTION
Fixes #69

Set `imap.Tagger` to be a `func() string` and tags will be generated using that function instead of hexified XIDs (which are too long for, at least, OpenResty's IMAP proxy module.)

Trivial example:
```
imap.Tagger = func() string {
	return strconv.FormatInt(time.Now().Unix(), 16)
}
```

Other options would be `ulid.Make().String()` (which is my preference and only 26 characters which doesn't annoy OpenResty.)