### PR TITLE
v1.0.0 prep: Options/Dial/Client + ctx + typed UIDs + typed errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ if err != nil { panic(err) }
 
 accessibleFolders := 0
 totalEmails := 0
-maxUID := 0
+var maxUID imap.UID
 
 for _, stat := range stats {
     if stat.Error != nil {
@@ -607,27 +607,28 @@ fmt.Println("Permanently deleted all marked emails")
 
 // Create an event handler
 handler := &imap.IdleHandler{
-    // New email arrived
+    // New email arrived. SeqNum is the new EXISTS count, which is also the
+    // sequence number of the newest message in the mailbox.
     OnExists: func(e imap.ExistsEvent) {
-        fmt.Printf("[EXISTS] New message at index: %d\n", e.MessageIndex)
-        // Example output: [EXISTS] New message at index: 343
+        fmt.Printf("[EXISTS] New message at sequence number: %d\n", e.SeqNum)
+        // Example output: [EXISTS] New message at sequence number: 343
 
-        // You might want to fetch the new email:
-        // uids, _ := m.GetUIDs(ctx, fmt.Sprintf("%d", e.MessageIndex))
+        // To fetch the new email, search by sequence number to resolve a UID:
+        // uids, _ := m.GetUIDs(ctx, fmt.Sprintf("%d", e.SeqNum))
         // emails, _ := m.GetEmails(ctx, uids...)
     },
 
     // Email was deleted/expunged
     OnExpunge: func(e imap.ExpungeEvent) {
-        fmt.Printf("[EXPUNGE] Message removed at index: %d\n", e.MessageIndex)
-        // Example output: [EXPUNGE] Message removed at index: 125
+        fmt.Printf("[EXPUNGE] Message removed at sequence number: %d\n", e.SeqNum)
+        // Example output: [EXPUNGE] Message removed at sequence number: 125
     },
 
     // Email flags changed (read, flagged, etc.)
     OnFetch: func(e imap.FetchEvent) {
-        fmt.Printf("[FETCH] Flags changed - Index: %d, UID: %d, Flags: %v\n",
-            e.MessageIndex, e.UID, e.Flags)
-        // Example output: [FETCH] Flags changed - Index: 42, UID: 245, Flags: [\Seen \Flagged]
+        fmt.Printf("[FETCH] Flags changed - SeqNum: %d, UID: %d, Flags: %v\n",
+            e.SeqNum, e.UID, e.Flags)
+        // Example output: [FETCH] Flags changed - SeqNum: 42, UID: 245, Flags: [\Seen \Flagged]
     },
 }
 
@@ -651,10 +652,10 @@ func monitorInbox(m *imap.Dialer) {
 
     handler := &imap.IdleHandler{
         OnExists: func(e imap.ExistsEvent) {
-            fmt.Printf("📬 New email! Total messages now: %d\n", e.MessageIndex)
+            fmt.Printf("📬 New email! Total messages now: %d\n", e.SeqNum)
         },
         OnExpunge: func(e imap.ExpungeEvent) {
-            fmt.Printf("🗑️ Email deleted at position %d\n", e.MessageIndex)
+            fmt.Printf("🗑️ Email deleted at position %d\n", e.SeqNum)
         },
         OnFetch: func(e imap.FetchEvent) {
             fmt.Printf("📝 Email %d updated with flags: %v\n", e.UID, e.Flags)
@@ -857,7 +858,7 @@ func main() {
     fmt.Println("\n👀 Monitoring for new emails (10 seconds)...")
     handler := &imap.IdleHandler{
         OnExists: func(e imap.ExistsEvent) {
-            fmt.Printf("  📬 New email arrived! (message #%d)\n", e.MessageIndex)
+            fmt.Printf("  📬 New email arrived! (message #%d)\n", e.SeqNum)
         },
     }
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ deadlines or cancellation; the examples below assume
 
 ```go
 // List all folders
-folders, err := m.GetFolders(ctx)
+folders, err := c.GetFolders(ctx)
 if err != nil { panic(err) }
 
 // Example output:
@@ -172,17 +172,17 @@ for _, folder := range folders {
 }
 
 // Select a folder for operations (read-write mode)
-err = m.SelectFolder(ctx, "INBOX")
+err = c.SelectFolder(ctx, "INBOX")
 if err != nil { panic(err) }
 
 // Select folder in read-only mode
-err = m.ExamineFolder(ctx, "INBOX")
+err = c.ExamineFolder(ctx, "INBOX")
 if err != nil { panic(err) }
 
 // Total email count across all folders. Per-folder failures (common with
 // Gmail's virtual system folders) are returned in folderErrors and do NOT
 // abort the iteration; err is only non-nil if the folder list itself fails.
-totalCount, folderErrors, err := m.TotalEmailCount(ctx, imap.CountOptions{})
+totalCount, folderErrors, err := c.TotalEmailCount(ctx, imap.CountOptions{})
 if err != nil { panic(err) }
 fmt.Printf("Total accessible emails: %d\n", totalCount)
 
@@ -199,24 +199,24 @@ if len(folderErrors) > 0 {
 //   - folder "[Gmail]/All Mail": NO [NONEXISTENT] Unknown Mailbox
 
 // Count excluding certain folders
-count, _, err := m.TotalEmailCount(ctx, imap.CountOptions{
+count, _, err := c.TotalEmailCount(ctx, imap.CountOptions{
     ExcludeFolders: []string{"Trash", "[Gmail]/Spam"},
 })
 if err != nil { panic(err) }
 fmt.Printf("Total emails (excluding spam/trash): %d\n", count)
 
 // Create, rename, and delete folders
-err = m.CreateFolder(ctx, "INBOX/Projects")
+err = c.CreateFolder(ctx, "INBOX/Projects")
 if err != nil { panic(err) }
 
-err = m.RenameFolder(ctx, "INBOX/Projects", "INBOX/Archive")
+err = c.RenameFolder(ctx, "INBOX/Projects", "INBOX/Archive")
 if err != nil { panic(err) }
 
-err = m.DeleteFolder(ctx, "INBOX/Archive")
+err = c.DeleteFolder(ctx, "INBOX/Archive")
 if err != nil { panic(err) }
 
 // Get detailed statistics for each folder (includes max UID)
-stats, err := m.FolderStats(ctx, imap.CountOptions{})
+stats, err := c.FolderStats(ctx, imap.CountOptions{})
 if err != nil { panic(err) }
 
 fmt.Printf("Found %d folders:\n", len(stats))
@@ -252,7 +252,7 @@ Some IMAP servers (especially Gmail) have special system folders that cannot be 
 
 ```go
 // Per-folder failures are reported, not raised
-totalCount, folderErrors, err := m.TotalEmailCount(ctx, imap.CountOptions{})
+totalCount, folderErrors, err := c.TotalEmailCount(ctx, imap.CountOptions{})
 if err != nil {
     // Only fails on serious connection issues, not individual folder problems
     panic(err)
@@ -264,14 +264,14 @@ if len(folderErrors) > 0 {
 }
 
 // Combine error tolerance with folder filtering
-count, _, err := m.TotalEmailCount(ctx, imap.CountOptions{
+count, _, err := c.TotalEmailCount(ctx, imap.CountOptions{
     ExcludeFolders: []string{"Trash", "Junk", "Deleted Items"},
 })
 if err != nil { panic(err) }
 fmt.Printf("Active emails: %d (excluding trash/spam)\n", count)
 
 // Detailed analysis with per-folder error handling
-stats, err := m.FolderStats(ctx, imap.CountOptions{})
+stats, err := c.FolderStats(ctx, imap.CountOptions{})
 if err != nil { panic(err) }
 
 accessibleFolders := 0
@@ -301,7 +301,7 @@ fmt.Printf("\nSummary: %d/%d folders accessible, %d total emails, highest UID: %
 #### Error Types You Might Encounter
 
 ```go
-stats, err := m.FolderStats(ctx, imap.CountOptions{})
+stats, err := c.FolderStats(ctx, imap.CountOptions{})
 if err != nil { panic(err) }
 
 for _, stat := range stats {
@@ -324,15 +324,15 @@ for _, stat := range stats {
 
 ```go
 // Select folder first
-err := m.SelectFolder(ctx, "INBOX")
+err := c.SelectFolder(ctx, "INBOX")
 if err != nil { panic(err) }
 
 // Basic searches - returns slice of UIDs
-allUIDs, _ := m.GetUIDs(ctx, "ALL")           // All emails
-unseenUIDs, _ := m.GetUIDs(ctx, "UNSEEN")     // Unread emails
-recentUIDs, _ := m.GetUIDs(ctx, "RECENT")     // Recent emails
-seenUIDs, _ := m.GetUIDs(ctx, "SEEN")         // Read emails
-flaggedUIDs, _ := m.GetUIDs(ctx, "FLAGGED")   // Starred/flagged emails
+allUIDs, _ := c.GetUIDs(ctx, "ALL")           // All emails
+unseenUIDs, _ := c.GetUIDs(ctx, "UNSEEN")     // Unread emails
+recentUIDs, _ := c.GetUIDs(ctx, "RECENT")     // Recent emails
+seenUIDs, _ := c.GetUIDs(ctx, "SEEN")         // Read emails
+flaggedUIDs, _ := c.GetUIDs(ctx, "FLAGGED")   // Starred/flagged emails
 
 // Example output:
 fmt.Printf("Found %d total emails\n", len(allUIDs))      // Found 342 total emails
@@ -340,57 +340,57 @@ fmt.Printf("Found %d unread emails\n", len(unseenUIDs))  // Found 12 unread emai
 fmt.Printf("UIDs of unread: %v\n", unseenUIDs)           // UIDs of unread: [245 246 247 251 252 253 254 255 256 257 258 259]
 
 // Date-based searches
-todayUIDs, _ := m.GetUIDs(ctx, "ON 15-Sep-2024")
-sinceUIDs, _ := m.GetUIDs(ctx, "SINCE 10-Sep-2024")
-beforeUIDs, _ := m.GetUIDs(ctx, "BEFORE 20-Sep-2024")
-rangeUIDs, _ := m.GetUIDs(ctx, "SINCE 1-Sep-2024 BEFORE 30-Sep-2024")
+todayUIDs, _ := c.GetUIDs(ctx, "ON 15-Sep-2024")
+sinceUIDs, _ := c.GetUIDs(ctx, "SINCE 10-Sep-2024")
+beforeUIDs, _ := c.GetUIDs(ctx, "BEFORE 20-Sep-2024")
+rangeUIDs, _ := c.GetUIDs(ctx, "SINCE 1-Sep-2024 BEFORE 30-Sep-2024")
 
 // From/To searches
-fromBossUIDs, _ := m.GetUIDs(ctx, `FROM "boss@company.com"`)
-toMeUIDs, _ := m.GetUIDs(ctx, `TO "me@company.com"`)
+fromBossUIDs, _ := c.GetUIDs(ctx, `FROM "boss@company.com"`)
+toMeUIDs, _ := c.GetUIDs(ctx, `TO "me@company.com"`)
 
 // Subject/body searches
-subjectUIDs, _ := m.GetUIDs(ctx, `SUBJECT "invoice"`)
-bodyUIDs, _ := m.GetUIDs(ctx, `BODY "payment"`)
-textUIDs, _ := m.GetUIDs(ctx, `TEXT "urgent"`) // Searches both subject and body
+subjectUIDs, _ := c.GetUIDs(ctx, `SUBJECT "invoice"`)
+bodyUIDs, _ := c.GetUIDs(ctx, `BODY "payment"`)
+textUIDs, _ := c.GetUIDs(ctx, `TEXT "urgent"`) // Searches both subject and body
 
 // Complex searches
-complexUIDs, _ := m.GetUIDs(ctx, `UNSEEN FROM "support@github.com" SINCE 1-Sep-2024`)
+complexUIDs, _ := c.GetUIDs(ctx, `UNSEEN FROM "support@github.com" SINCE 1-Sep-2024`)
 
 // UID ranges (raw IMAP syntax)
-firstUID, _ := m.GetUIDs(ctx, "1")          // UID 1 only
-lastUID, _ := m.GetUIDs(ctx, "*")           // Highest UID only
-rangeUIDs, _ := m.GetUIDs(ctx, "1:10")      // UIDs 1 through 10
+firstUID, _ := c.GetUIDs(ctx, "1")          // UID 1 only
+lastUID, _ := c.GetUIDs(ctx, "*")           // Highest UID only
+rangeUIDs, _ := c.GetUIDs(ctx, "1:10")      // UIDs 1 through 10
 
 // Get the N most recent messages (recommended for "last N" queries)
-last10UIDs, _ := m.GetLastNUIDs(ctx, 10)    // Last 10 messages by UID
+last10UIDs, _ := c.GetLastNUIDs(ctx, 10)    // Last 10 messages by UID
 
 // Cheaper method to retrieve the latest UID (requires RFC-4731;
 // not all servers support this — check the error).
-maxUID, _ := m.GetMaxUID(ctx)             // Highest UID only
+maxUID, _ := c.GetMaxUID(ctx)             // Highest UID only
 
 // Size-based searches
-largeUIDs, _ := m.GetUIDs(ctx, "LARGER 10485760")  // Emails larger than 10MB
-smallUIDs, _ := m.GetUIDs(ctx, "SMALLER 1024")     // Emails smaller than 1KB
+largeUIDs, _ := c.GetUIDs(ctx, "LARGER 10485760")  // Emails larger than 10MB
+smallUIDs, _ := c.GetUIDs(ctx, "SMALLER 1024")     // Emails smaller than 1KB
 
 // Non-ASCII searches using RFC 3501 literal syntax
 // The library automatically detects and handles literal syntax {n}
 // where n is the byte count of the following data
 
 // Search for Cyrillic text in subject (тест = 8 bytes in UTF-8)
-cyrillicUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 Subject {8}\r\nтест")
+cyrillicUIDs, _ := c.GetUIDs(ctx, "CHARSET UTF-8 Subject {8}\r\nтест")
 
 // Search for Chinese text in subject (测试 = 6 bytes in UTF-8)  
-chineseUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 Subject {6}\r\n测试")
+chineseUIDs, _ := c.GetUIDs(ctx, "CHARSET UTF-8 Subject {6}\r\n测试")
 
 // Search for Japanese text in body (テスト = 9 bytes in UTF-8)
-japaneseUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 BODY {9}\r\nテスト")
+japaneseUIDs, _ := c.GetUIDs(ctx, "CHARSET UTF-8 BODY {9}\r\nテスト")
 
 // Search for Arabic text (اختبار = 12 bytes in UTF-8)
-arabicUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 TEXT {12}\r\nاختبار")
+arabicUIDs, _ := c.GetUIDs(ctx, "CHARSET UTF-8 TEXT {12}\r\nاختبار")
 
 // Search with emoji (😀👍 = 8 bytes in UTF-8)
-emojiUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 TEXT {8}\r\n😀👍")
+emojiUIDs, _ := c.GetUIDs(ctx, "CHARSET UTF-8 TEXT {8}\r\n😀👍")
 
 // Note: Always specify CHARSET UTF-8 for non-ASCII searches
 // The {n} syntax tells the server exactly how many bytes to expect
@@ -403,10 +403,10 @@ For complex or repeated queries, use the fluent `SearchBuilder` instead of raw s
 
 ```go
 // Simple search
-uids, _ := m.SearchUIDs(ctx, imap.Search().Unseen())
+uids, _ := c.SearchUIDs(ctx, imap.Search().Unseen())
 
 // Combine multiple criteria (AND)
-uids, _ = m.SearchUIDs(ctx, 
+uids, _ = c.SearchUIDs(ctx, 
     imap.Search().
         From("boss@company.com").
         Since(time.Now().AddDate(0, 0, -7)).
@@ -415,38 +415,38 @@ uids, _ = m.SearchUIDs(ctx,
 
 // Date range
 lastMonth := time.Now().AddDate(0, -1, 0)
-uids, _ = m.SearchUIDs(ctx, 
+uids, _ = c.SearchUIDs(ctx, 
     imap.Search().Since(lastMonth).Before(time.Now()).Flagged(),
 )
 
 // OR and NOT operators
-uids, _ = m.SearchUIDs(ctx, 
+uids, _ = c.SearchUIDs(ctx, 
     imap.Search().Or(
         imap.Search().From("alice@example.com"),
         imap.Search().From("bob@example.com"),
     ).Unseen(),
 )
 
-uids, _ = m.SearchUIDs(ctx, 
+uids, _ = c.SearchUIDs(ctx, 
     imap.Search().Not(imap.Search().From("noreply@")).Unseen(),
 )
 
 // Size filters
-uids, _ = m.SearchUIDs(ctx, imap.Search().Larger(10 * 1024 * 1024)) // > 10MB
+uids, _ = c.SearchUIDs(ctx, imap.Search().Larger(10 * 1024 * 1024)) // > 10MB
 
 // Non-ASCII text is handled automatically (CHARSET UTF-8 + literal syntax)
-uids, _ = m.SearchUIDs(ctx, imap.Search().Subject("日報"))
+uids, _ = c.SearchUIDs(ctx, imap.Search().Subject("日報"))
 
 // You can also use Build() to get the raw string for GetUIDs()
 query := imap.Search().From("alice").Unseen().Since(lastMonth).Build()
-uids, _ = m.GetUIDs(ctx, query)
+uids, _ = c.GetUIDs(ctx, query)
 ```
 
 ### 3. Fetching Email Details
 
 ```go
 // Get overview (headers only, no body) - FAST
-overviews, err := m.GetOverviews(ctx, uids...)
+overviews, err := c.GetOverviews(ctx, uids...)
 if err != nil { panic(err) }
 
 for uid, email := range overviews {
@@ -467,7 +467,7 @@ for uid, email := range overviews {
 //   Flags: [\Seen]
 
 // Get full emails with bodies - SLOWER
-emails, err := m.GetEmails(ctx, uids...)
+emails, err := c.GetEmails(ctx, uids...)
 if err != nil { panic(err) }
 
 for uid, email := range emails {
@@ -534,24 +534,24 @@ fmt.Print(email)
 ```go
 // === Moving and Copying Emails ===
 uid := 245
-err = m.MoveEmail(ctx, uid, "INBOX/Archive")
+err = c.MoveEmail(ctx, uid, "INBOX/Archive")
 if err != nil { panic(err) }
 fmt.Printf("Moved email %d to Archive\n", uid)
 
 // Copy keeps the original in the current folder
-err = m.CopyEmail(ctx, uid, "INBOX/Backup")
+err = c.CopyEmail(ctx, uid, "INBOX/Backup")
 if err != nil { panic(err) }
 fmt.Printf("Copied email %d to Backup\n", uid)
 
 // === Uploading Messages (APPEND) ===
 msg := []byte("From: me@example.com\r\nTo: you@example.com\r\nSubject: Hello\r\n\r\nMessage body")
-err = m.Append(ctx, "Drafts", []string{`\Draft`, `\Seen`}, time.Now(), msg)
+err = c.Append(ctx, "Drafts", []string{`\Draft`, `\Seen`}, time.Now(), msg)
 if err != nil { panic(err) }
 fmt.Println("Uploaded draft message")
 
 // === Setting Flags ===
 // Mark as read
-err = m.MarkSeen(ctx, uid)
+err = c.MarkSeen(ctx, uid)
 if err != nil { panic(err) }
 
 // Set multiple flags at once
@@ -560,7 +560,7 @@ flags := imap.Flags{
     Flagged:  imap.FlagAdd,      // Star/flag the email
     Answered: imap.FlagRemove,   // Remove answered flag
 }
-err = m.SetFlags(ctx, uid, flags)
+err = c.SetFlags(ctx, uid, flags)
 if err != nil { panic(err) }
 
 // Custom keywords (if server supports)
@@ -571,17 +571,17 @@ flags = imap.Flags{
         "$Pending":   false,     // Remove this keyword
     },
 }
-err = m.SetFlags(ctx, uid, flags)
+err = c.SetFlags(ctx, uid, flags)
 if err != nil { panic(err) }
 
 // === Deleting Emails ===
 // Step 1: Mark as deleted (sets \Deleted flag)
-err = m.DeleteEmail(ctx, uid)
+err = c.DeleteEmail(ctx, uid)
 if err != nil { panic(err) }
 fmt.Printf("Marked email %d for deletion\n", uid)
 
 // Step 2: Expunge to permanently remove all \Deleted emails
-err = m.Expunge(ctx)
+err = c.Expunge(ctx)
 if err != nil { panic(err) }
 fmt.Println("Permanently deleted all marked emails")
 
@@ -604,8 +604,8 @@ handler := &imap.IdleHandler{
         // Example output: [EXISTS] New message at sequence number: 343
 
         // To fetch the new email, search by sequence number to resolve a UID:
-        // uids, _ := m.GetUIDs(ctx, fmt.Sprintf("%d", e.SeqNum))
-        // emails, _ := m.GetEmails(ctx, uids...)
+        // uids, _ := c.GetUIDs(ctx, fmt.Sprintf("%d", e.SeqNum))
+        // emails, _ := c.GetEmails(ctx, uids...)
     },
 
     // Email was deleted/expunged
@@ -623,20 +623,20 @@ handler := &imap.IdleHandler{
 }
 
 // Start IDLE (non-blocking, runs in background)
-err := m.StartIdle(ctx, handler)
+err := c.StartIdle(ctx, handler)
 if err != nil { panic(err) }
 
 // Your application continues running...
 // IDLE events will be handled in the background
 
 // When you're done, stop IDLE
-err = m.StopIdle()
+err = c.StopIdle()
 if err != nil { panic(err) }
 
 // Full example with proper lifecycle:
-func monitorInbox(m *imap.Dialer) {
+func monitorInbox(ctx context.Context, c *imap.Client) {
     // Select the folder to monitor
-    if err := m.SelectFolder(ctx, "INBOX"); err != nil {
+    if err := c.SelectFolder(ctx, "INBOX"); err != nil {
         panic(err)
     }
 
@@ -653,7 +653,7 @@ func monitorInbox(m *imap.Dialer) {
     }
 
     fmt.Println("Starting IDLE monitoring...")
-    if err := m.StartIdle(ctx, handler); err != nil {
+    if err := c.StartIdle(ctx, handler); err != nil {
         panic(err)
     }
 
@@ -661,7 +661,7 @@ func monitorInbox(m *imap.Dialer) {
     time.Sleep(30 * time.Minute)
 
     fmt.Println("Stopping IDLE monitoring...")
-    if err := m.StopIdle(); err != nil {
+    if err := c.StopIdle(); err != nil {
         panic(err)
     }
 }
@@ -673,26 +673,26 @@ func monitorInbox(m *imap.Dialer) {
 // The library automatically handles reconnection for most operations
 // But here's how to handle errors properly:
 
-func robustEmailFetch(m *imap.Dialer) {
+func robustEmailFetch(ctx context.Context, c *imap.Client) {
     // Set retry configuration
     imap.RetryCount = 5  // Will retry failed operations 5 times
     imap.Verbose = true  // Emit debug logs while retrying commands
 
-    err := m.SelectFolder(ctx, "INBOX")
+    err := c.SelectFolder(ctx, "INBOX")
     if err != nil {
         // Connection errors are automatically retried
         // This only fails after all retries are exhausted
         fmt.Printf("Failed to select folder after %d retries: %v\n", imap.RetryCount, err)
 
         // You might want to manually reconnect
-        if err := m.Reconnect(ctx); err != nil {
+        if err := c.Reconnect(ctx); err != nil {
             fmt.Printf("Manual reconnection failed: %v\n", err)
             return
         }
     }
 
     // Fetch emails with automatic retry on network issues
-    uids, err := m.GetUIDs(ctx, "UNSEEN")
+    uids, err := c.GetUIDs(ctx, "UNSEEN")
     if err != nil {
         fmt.Printf("Search failed: %v\n", err)
         return
@@ -705,7 +705,7 @@ func robustEmailFetch(m *imap.Dialer) {
     // 4. Re-select the previously selected folder
     // 5. Retry the failed command
 
-    emails, err := m.GetEmails(ctx, uids...)
+    emails, err := c.GetEmails(ctx, uids...)
     if err != nil {
         fmt.Printf("Fetch failed after retries: %v\n", err)
         return
@@ -715,26 +715,29 @@ func robustEmailFetch(m *imap.Dialer) {
 }
 
 // Timeout configuration
-func configureTimeouts() {
-    // Connection timeout (for initial connection)
-    imap.DialTimeout = 10 * time.Second
-
-    // Command timeout (for each IMAP command)
-    imap.CommandTimeout = 30 * time.Second
-
-    // Now commands will timeout if they take too long
-    m, err := imap.New("user", "pass", "mail.server.com", 993)
+func configureTimeouts(ctx context.Context) {
+    // Dial establishes the TCP + TLS + authentication within DialTimeout;
+    // CommandTimeout caps each subsequent IMAP command.
+    c, err := imap.Dial(ctx, imap.Options{
+        Host:           "mail.server.com",
+        Port:           993,
+        Auth:           imap.PasswordAuth{Username: "user", Password: "pass"},
+        DialTimeout:    10 * time.Second,
+        CommandTimeout: 30 * time.Second,
+    })
     if err != nil {
-        // Connection failed within 10 seconds
+        // Connection failed within DialTimeout
         panic(err)
     }
-    defer m.Close()
+    defer c.Close()
 
-    // This search will timeout after 30 seconds
-    uids, err := m.GetUIDs(ctx, "ALL")
+    // This search will be bounded by CommandTimeout (or by ctx's deadline,
+    // whichever is shorter).
+    uids, err := c.GetUIDs(ctx, "ALL")
     if err != nil {
         fmt.Printf("Command timed out or failed: %v\n", err)
     }
+    _ = uids
 }
 ```
 
@@ -744,6 +747,7 @@ func configureTimeouts() {
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "time"
@@ -754,21 +758,26 @@ import (
 func main() {
     // Configure the library
     imap.Verbose = false
-    imap.RetryCount = 3
-    imap.DialTimeout = 10 * time.Second
-    imap.CommandTimeout = 30 * time.Second
 
     // Connect
+    ctx := context.Background()
     fmt.Println("Connecting to IMAP server...")
-    m, err := imap.New("your-email@gmail.com", "your-password", "imap.gmail.com", 993)
+    c, err := imap.Dial(ctx, imap.Options{
+        Host:           "imap.gmail.com",
+        Port:           993,
+        Auth:           imap.PasswordAuth{Username: "your-email@gmail.com", Password: "your-password"},
+        DialTimeout:    10 * time.Second,
+        CommandTimeout: 30 * time.Second,
+        RetryCount:     3,
+    })
     if err != nil {
         log.Fatalf("Connection failed: %v", err)
     }
-    defer m.Close()
+    defer c.Close()
 
     // List folders
     fmt.Println("\n📁 Available folders:")
-    folders, err := m.GetFolders(ctx)
+    folders, err := c.GetFolders(ctx)
     if err != nil {
         log.Fatalf("Failed to get folders: %v", err)
     }
@@ -778,13 +787,13 @@ func main() {
 
     // Select INBOX
     fmt.Println("\n📥 Selecting INBOX...")
-    if err := m.SelectFolder(ctx, "INBOX"); err != nil {
+    if err := c.SelectFolder(ctx, "INBOX"); err != nil {
         log.Fatalf("Failed to select INBOX: %v", err)
     }
 
     // Get unread emails
     fmt.Println("\n🔍 Searching for unread emails...")
-    unreadUIDs, err := m.GetUIDs(ctx, "UNSEEN")
+    unreadUIDs, err := c.GetUIDs(ctx, "UNSEEN")
     if err != nil {
         log.Fatalf("Search failed: %v", err)
     }
@@ -798,7 +807,7 @@ func main() {
 
     if limit > 0 {
         fmt.Printf("\n📧 Fetching first %d unread emails...\n", limit)
-        emails, err := m.GetEmails(ctx, unreadUIDs[:limit]...)
+        emails, err := c.GetEmails(ctx, unreadUIDs[:limit]...)
         if err != nil {
             log.Fatalf("Failed to fetch emails: %v", err)
         }
@@ -826,7 +835,7 @@ func main() {
             // Mark first email as read
             if uid == unreadUIDs[0] {
                 fmt.Printf("\n✓ Marking email %d as read...\n", uid)
-                if err := m.MarkSeen(ctx, uid); err != nil {
+                if err := c.MarkSeen(ctx, uid); err != nil {
                     fmt.Printf("Failed to mark as read: %v\n", err)
                 }
             }
@@ -835,9 +844,9 @@ func main() {
 
     // Get some statistics
     fmt.Println("\n📊 Mailbox Statistics:")
-    allUIDs, _ := m.GetUIDs(ctx, "ALL")
-    seenUIDs, _ := m.GetUIDs(ctx, "SEEN")
-    flaggedUIDs, _ := m.GetUIDs(ctx, "FLAGGED")
+    allUIDs, _ := c.GetUIDs(ctx, "ALL")
+    seenUIDs, _ := c.GetUIDs(ctx, "SEEN")
+    flaggedUIDs, _ := c.GetUIDs(ctx, "FLAGGED")
 
     fmt.Printf("  Total emails: %d\n", len(allUIDs))
     fmt.Printf("  Read emails: %d\n", len(seenUIDs))
@@ -852,9 +861,9 @@ func main() {
         },
     }
 
-    if err := m.StartIdle(ctx, handler); err == nil {
+    if err := c.StartIdle(ctx, handler); err == nil {
         time.Sleep(10 * time.Second)
-        _ = m.StopIdle()
+        _ = c.StopIdle()
     }
 
     fmt.Println("\n✅ Done!")

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ func main() {
     // For self-signed certificates (use with caution!)
     // imap.TLSSkipVerify = true
 
-    c, err := imap.Dial(context.Background(), imap.Options{
+    ctx := context.Background()
+    c, err := imap.Dial(ctx, imap.Options{
         Host:           "mail.server.com",
         Port:           993,
         Auth:           imap.PasswordAuth{Username: "username", Password: "password"},
@@ -60,7 +61,7 @@ func main() {
     if err != nil { panic(err) }
     defer c.Close()
 
-    folders, err := c.GetFolders()
+    folders, err := c.GetFolders(ctx)
     if err != nil { panic(err) }
     fmt.Printf("Connected! Found %d folders\n", len(folders))
 }
@@ -69,7 +70,8 @@ func main() {
 ### OAuth 2.0 Authentication (XOAUTH2)
 
 ```go
-c, err := imap.Dial(context.Background(), imap.Options{
+ctx := context.Background()
+c, err := imap.Dial(ctx, imap.Options{
     Host: "imap.gmail.com",
     Port: 993,
     Auth: imap.XOAuth2{Username: "user@example.com", AccessToken: accessToken},
@@ -78,7 +80,7 @@ if err != nil { panic(err) }
 defer c.Close()
 
 // The OAuth2 connection works exactly like LOGIN after authentication.
-if err := c.SelectFolder("INBOX"); err != nil { panic(err) }
+if err := c.SelectFolder(ctx, "INBOX"); err != nil { panic(err) }
 ```
 
 ## Logging
@@ -177,22 +179,12 @@ if err != nil { panic(err) }
 err = m.ExamineFolder(ctx, "INBOX")
 if err != nil { panic(err) }
 
-// Get total email count across all folders
-totalCount, err := m.GetTotalEmailCount(ctx)
+// Total email count across all folders. Per-folder failures (common with
+// Gmail's virtual system folders) are returned in folderErrors and do NOT
+// abort the iteration; err is only non-nil if the folder list itself fails.
+totalCount, folderErrors, err := m.TotalEmailCount(ctx, imap.CountOptions{})
 if err != nil { panic(err) }
-fmt.Printf("Total emails in all folders: %d\n", totalCount)
-
-// Get count excluding certain folders
-excludedFolders := []string{"Trash", "[Gmail]/Spam"}
-count, err := m.GetTotalEmailCountExcluding(ctx, excludedFolders)
-if err != nil { panic(err) }
-fmt.Printf("Total emails (excluding spam/trash): %d\n", count)
-
-// Error-tolerant counting (continues even if some folders fail)
-// This is especially useful with Gmail or other providers that have inaccessible system folders
-safeCount, folderErrors, err := m.GetTotalEmailCountSafe(ctx)
-if err != nil { panic(err) }
-fmt.Printf("Total accessible emails: %d\n", safeCount)
+fmt.Printf("Total accessible emails: %d\n", totalCount)
 
 if len(folderErrors) > 0 {
     fmt.Printf("Note: %d folders had errors:\n", len(folderErrors))
@@ -206,6 +198,13 @@ if len(folderErrors) > 0 {
 //   - folder "[Gmail]": NO [NONEXISTENT] Unknown Mailbox
 //   - folder "[Gmail]/All Mail": NO [NONEXISTENT] Unknown Mailbox
 
+// Count excluding certain folders
+count, _, err := m.TotalEmailCount(ctx, imap.CountOptions{
+    ExcludeFolders: []string{"Trash", "[Gmail]/Spam"},
+})
+if err != nil { panic(err) }
+fmt.Printf("Total emails (excluding spam/trash): %d\n", count)
+
 // Create, rename, and delete folders
 err = m.CreateFolder(ctx, "INBOX/Projects")
 if err != nil { panic(err) }
@@ -217,7 +216,7 @@ err = m.DeleteFolder(ctx, "INBOX/Archive")
 if err != nil { panic(err) }
 
 // Get detailed statistics for each folder (includes max UID)
-stats, err := m.GetFolderStats(ctx)
+stats, err := m.FolderStats(ctx, imap.CountOptions{})
 if err != nil { panic(err) }
 
 fmt.Printf("Found %d folders:\n", len(stats))
@@ -243,45 +242,36 @@ for _, stat := range stats {
 
 ### 1.1. Handling Problematic Folders
 
-Some IMAP servers (especially Gmail) have special system folders that cannot be examined or may return errors. The traditional `GetTotalEmailCount()` method will fail completely if any folder is inaccessible, but the new safe methods continue processing other folders.
+Some IMAP servers (especially Gmail) have special system folders that cannot be examined or may return errors. `TotalEmailCount` and `FolderStats` are designed to tolerate these: per-folder failures are returned alongside the partial result rather than aborting the iteration. The top-level `err` is only set if the initial folder list cannot be retrieved.
 
-#### When to Use Safe Methods
+#### When per-folder errors show up
 
-- **Gmail users**: Gmail's `[Gmail]` folder often returns "NO [NONEXISTENT] Unknown Mailbox"
+- **Gmail users**: The `[Gmail]` folder often returns "NO [NONEXISTENT] Unknown Mailbox"
 - **Exchange/Office 365**: Some system folders may be restricted
 - **Custom IMAP servers**: Servers with permission-restricted folders
-- **Production applications**: When you need reliable email counting despite folder issues
 
 ```go
-// Traditional approach - fails if ANY folder has issues
-totalCount, err := m.GetTotalEmailCount(ctx)
-if err != nil {
-    // This will fail completely if "[Gmail]" folder is inaccessible
-    fmt.Printf("Count failed: %v\n", err)
-    // Output: Count failed: EXAMINE command failed: NO [NONEXISTENT] Unknown Mailbox
-}
-
-// Safe approach - continues despite folder errors
-safeCount, folderErrors, err := m.GetTotalEmailCountSafe(ctx)
+// Per-folder failures are reported, not raised
+totalCount, folderErrors, err := m.TotalEmailCount(ctx, imap.CountOptions{})
 if err != nil {
     // Only fails on serious connection issues, not individual folder problems
     panic(err)
 }
 
-fmt.Printf("Counted %d emails from accessible folders\n", safeCount)
+fmt.Printf("Counted %d emails from accessible folders\n", totalCount)
 if len(folderErrors) > 0 {
     fmt.Printf("Skipped %d problematic folders\n", len(folderErrors))
 }
 
-// Safe exclusion - combine error tolerance with folder filtering
-excludedFolders := []string{"Trash", "Junk", "Deleted Items"}
-count, folderErrors, err := m.GetTotalEmailCountSafeExcluding(ctx, excludedFolders)
+// Combine error tolerance with folder filtering
+count, _, err := m.TotalEmailCount(ctx, imap.CountOptions{
+    ExcludeFolders: []string{"Trash", "Junk", "Deleted Items"},
+})
 if err != nil { panic(err) }
+fmt.Printf("Active emails: %d (excluding trash/spam)\n", count)
 
-fmt.Printf("Active emails: %d (excluding trash/spam and skipping errors)\n", count)
-
-// Detailed analysis with error handling
-stats, err := m.GetFolderStats(ctx)
+// Detailed analysis with per-folder error handling
+stats, err := m.FolderStats(ctx, imap.CountOptions{})
 if err != nil { panic(err) }
 
 accessibleFolders := 0
@@ -311,7 +301,7 @@ fmt.Printf("\nSummary: %d/%d folders accessible, %d total emails, highest UID: %
 #### Error Types You Might Encounter
 
 ```go
-stats, err := m.GetFolderStats(ctx)
+stats, err := m.FolderStats(ctx, imap.CountOptions{})
 if err != nil { panic(err) }
 
 for _, stat := range stats {

--- a/README.md
+++ b/README.md
@@ -37,28 +37,30 @@ Requires Go 1.25+ (see `go.mod`).
 package main
 
 import (
+    "context"
     "fmt"
     "time"
     imap "github.com/BrianLeishman/go-imap"
 )
 
 func main() {
-    // Optional configuration
-    imap.Verbose = false      // Enable to emit debug-level IMAP logs
-    imap.RetryCount = 3        // Number of retries for failed commands
-    imap.DialTimeout = 10 * time.Second
-    imap.CommandTimeout = 30 * time.Second
+    imap.Verbose = false // Enable to emit debug-level IMAP logs
 
     // For self-signed certificates (use with caution!)
     // imap.TLSSkipVerify = true
 
-    // Connect with standard LOGIN authentication
-    m, err := imap.New("username", "password", "mail.server.com", 993)
+    c, err := imap.Dial(context.Background(), imap.Options{
+        Host:           "mail.server.com",
+        Port:           993,
+        Auth:           imap.PasswordAuth{Username: "username", Password: "password"},
+        DialTimeout:    10 * time.Second,
+        CommandTimeout: 30 * time.Second,
+        RetryCount:     3,
+    })
     if err != nil { panic(err) }
-    defer m.Close()
+    defer c.Close()
 
-    // Quick test
-    folders, err := m.GetFolders()
+    folders, err := c.GetFolders()
     if err != nil { panic(err) }
     fmt.Printf("Connected! Found %d folders\n", len(folders))
 }
@@ -67,13 +69,16 @@ func main() {
 ### OAuth 2.0 Authentication (XOAUTH2)
 
 ```go
-// Connect with OAuth2 (Gmail, Office 365, etc.)
-m, err := imap.NewWithOAuth2("user@example.com", accessToken, "imap.gmail.com", 993)
+c, err := imap.Dial(context.Background(), imap.Options{
+    Host: "imap.gmail.com",
+    Port: 993,
+    Auth: imap.XOAuth2{Username: "user@example.com", AccessToken: accessToken},
+})
 if err != nil { panic(err) }
-defer m.Close()
+defer c.Close()
 
-// The OAuth2 connection works exactly like LOGIN after authentication
-if err := m.SelectFolder("INBOX"); err != nil { panic(err) }
+// The OAuth2 connection works exactly like LOGIN after authentication.
+if err := c.SelectFolder("INBOX"); err != nil { panic(err) }
 ```
 
 ## Logging
@@ -137,11 +142,15 @@ go run examples/basic_connection/main.go
 
 ## Detailed Usage Examples
 
+All operations take a `context.Context` as the first argument so you can apply
+deadlines or cancellation; the examples below assume
+`ctx := context.Background()` unless stated otherwise.
+
 ### 1. Working with Folders
 
 ```go
 // List all folders
-folders, err := m.GetFolders()
+folders, err := m.GetFolders(ctx)
 if err != nil { panic(err) }
 
 // Example output:
@@ -161,27 +170,27 @@ for _, folder := range folders {
 }
 
 // Select a folder for operations (read-write mode)
-err = m.SelectFolder("INBOX")
+err = m.SelectFolder(ctx, "INBOX")
 if err != nil { panic(err) }
 
 // Select folder in read-only mode
-err = m.ExamineFolder("INBOX")
+err = m.ExamineFolder(ctx, "INBOX")
 if err != nil { panic(err) }
 
 // Get total email count across all folders
-totalCount, err := m.GetTotalEmailCount()
+totalCount, err := m.GetTotalEmailCount(ctx)
 if err != nil { panic(err) }
 fmt.Printf("Total emails in all folders: %d\n", totalCount)
 
 // Get count excluding certain folders
 excludedFolders := []string{"Trash", "[Gmail]/Spam"}
-count, err := m.GetTotalEmailCountExcluding(excludedFolders)
+count, err := m.GetTotalEmailCountExcluding(ctx, excludedFolders)
 if err != nil { panic(err) }
 fmt.Printf("Total emails (excluding spam/trash): %d\n", count)
 
 // Error-tolerant counting (continues even if some folders fail)
 // This is especially useful with Gmail or other providers that have inaccessible system folders
-safeCount, folderErrors, err := m.GetTotalEmailCountSafe()
+safeCount, folderErrors, err := m.GetTotalEmailCountSafe(ctx)
 if err != nil { panic(err) }
 fmt.Printf("Total accessible emails: %d\n", safeCount)
 
@@ -198,17 +207,17 @@ if len(folderErrors) > 0 {
 //   - folder "[Gmail]/All Mail": NO [NONEXISTENT] Unknown Mailbox
 
 // Create, rename, and delete folders
-err = m.CreateFolder("INBOX/Projects")
+err = m.CreateFolder(ctx, "INBOX/Projects")
 if err != nil { panic(err) }
 
-err = m.RenameFolder("INBOX/Projects", "INBOX/Archive")
+err = m.RenameFolder(ctx, "INBOX/Projects", "INBOX/Archive")
 if err != nil { panic(err) }
 
-err = m.DeleteFolder("INBOX/Archive")
+err = m.DeleteFolder(ctx, "INBOX/Archive")
 if err != nil { panic(err) }
 
 // Get detailed statistics for each folder (includes max UID)
-stats, err := m.GetFolderStats()
+stats, err := m.GetFolderStats(ctx)
 if err != nil { panic(err) }
 
 fmt.Printf("Found %d folders:\n", len(stats))
@@ -245,7 +254,7 @@ Some IMAP servers (especially Gmail) have special system folders that cannot be 
 
 ```go
 // Traditional approach - fails if ANY folder has issues
-totalCount, err := m.GetTotalEmailCount()
+totalCount, err := m.GetTotalEmailCount(ctx)
 if err != nil {
     // This will fail completely if "[Gmail]" folder is inaccessible
     fmt.Printf("Count failed: %v\n", err)
@@ -253,7 +262,7 @@ if err != nil {
 }
 
 // Safe approach - continues despite folder errors
-safeCount, folderErrors, err := m.GetTotalEmailCountSafe()
+safeCount, folderErrors, err := m.GetTotalEmailCountSafe(ctx)
 if err != nil {
     // Only fails on serious connection issues, not individual folder problems
     panic(err)
@@ -266,13 +275,13 @@ if len(folderErrors) > 0 {
 
 // Safe exclusion - combine error tolerance with folder filtering
 excludedFolders := []string{"Trash", "Junk", "Deleted Items"}
-count, folderErrors, err := m.GetTotalEmailCountSafeExcluding(excludedFolders)
+count, folderErrors, err := m.GetTotalEmailCountSafeExcluding(ctx, excludedFolders)
 if err != nil { panic(err) }
 
 fmt.Printf("Active emails: %d (excluding trash/spam and skipping errors)\n", count)
 
 // Detailed analysis with error handling
-stats, err := m.GetFolderStats()
+stats, err := m.GetFolderStats(ctx)
 if err != nil { panic(err) }
 
 accessibleFolders := 0
@@ -302,7 +311,7 @@ fmt.Printf("\nSummary: %d/%d folders accessible, %d total emails, highest UID: %
 #### Error Types You Might Encounter
 
 ```go
-stats, err := m.GetFolderStats()
+stats, err := m.GetFolderStats(ctx)
 if err != nil { panic(err) }
 
 for _, stat := range stats {
@@ -325,15 +334,15 @@ for _, stat := range stats {
 
 ```go
 // Select folder first
-err := m.SelectFolder("INBOX")
+err := m.SelectFolder(ctx, "INBOX")
 if err != nil { panic(err) }
 
 // Basic searches - returns slice of UIDs
-allUIDs, _ := m.GetUIDs("ALL")           // All emails
-unseenUIDs, _ := m.GetUIDs("UNSEEN")     // Unread emails
-recentUIDs, _ := m.GetUIDs("RECENT")     // Recent emails
-seenUIDs, _ := m.GetUIDs("SEEN")         // Read emails
-flaggedUIDs, _ := m.GetUIDs("FLAGGED")   // Starred/flagged emails
+allUIDs, _ := m.GetUIDs(ctx, "ALL")           // All emails
+unseenUIDs, _ := m.GetUIDs(ctx, "UNSEEN")     // Unread emails
+recentUIDs, _ := m.GetUIDs(ctx, "RECENT")     // Recent emails
+seenUIDs, _ := m.GetUIDs(ctx, "SEEN")         // Read emails
+flaggedUIDs, _ := m.GetUIDs(ctx, "FLAGGED")   // Starred/flagged emails
 
 // Example output:
 fmt.Printf("Found %d total emails\n", len(allUIDs))      // Found 342 total emails
@@ -341,57 +350,57 @@ fmt.Printf("Found %d unread emails\n", len(unseenUIDs))  // Found 12 unread emai
 fmt.Printf("UIDs of unread: %v\n", unseenUIDs)           // UIDs of unread: [245 246 247 251 252 253 254 255 256 257 258 259]
 
 // Date-based searches
-todayUIDs, _ := m.GetUIDs("ON 15-Sep-2024")
-sinceUIDs, _ := m.GetUIDs("SINCE 10-Sep-2024")
-beforeUIDs, _ := m.GetUIDs("BEFORE 20-Sep-2024")
-rangeUIDs, _ := m.GetUIDs("SINCE 1-Sep-2024 BEFORE 30-Sep-2024")
+todayUIDs, _ := m.GetUIDs(ctx, "ON 15-Sep-2024")
+sinceUIDs, _ := m.GetUIDs(ctx, "SINCE 10-Sep-2024")
+beforeUIDs, _ := m.GetUIDs(ctx, "BEFORE 20-Sep-2024")
+rangeUIDs, _ := m.GetUIDs(ctx, "SINCE 1-Sep-2024 BEFORE 30-Sep-2024")
 
 // From/To searches
-fromBossUIDs, _ := m.GetUIDs(`FROM "boss@company.com"`)
-toMeUIDs, _ := m.GetUIDs(`TO "me@company.com"`)
+fromBossUIDs, _ := m.GetUIDs(ctx, `FROM "boss@company.com"`)
+toMeUIDs, _ := m.GetUIDs(ctx, `TO "me@company.com"`)
 
 // Subject/body searches
-subjectUIDs, _ := m.GetUIDs(`SUBJECT "invoice"`)
-bodyUIDs, _ := m.GetUIDs(`BODY "payment"`)
-textUIDs, _ := m.GetUIDs(`TEXT "urgent"`) // Searches both subject and body
+subjectUIDs, _ := m.GetUIDs(ctx, `SUBJECT "invoice"`)
+bodyUIDs, _ := m.GetUIDs(ctx, `BODY "payment"`)
+textUIDs, _ := m.GetUIDs(ctx, `TEXT "urgent"`) // Searches both subject and body
 
 // Complex searches
-complexUIDs, _ := m.GetUIDs(`UNSEEN FROM "support@github.com" SINCE 1-Sep-2024`)
+complexUIDs, _ := m.GetUIDs(ctx, `UNSEEN FROM "support@github.com" SINCE 1-Sep-2024`)
 
 // UID ranges (raw IMAP syntax)
-firstUID, _ := m.GetUIDs("1")          // UID 1 only
-lastUID, _ := m.GetUIDs("*")           // Highest UID only
-rangeUIDs, _ := m.GetUIDs("1:10")      // UIDs 1 through 10
+firstUID, _ := m.GetUIDs(ctx, "1")          // UID 1 only
+lastUID, _ := m.GetUIDs(ctx, "*")           // Highest UID only
+rangeUIDs, _ := m.GetUIDs(ctx, "1:10")      // UIDs 1 through 10
 
 // Get the N most recent messages (recommended for "last N" queries)
-last10UIDs, _ := m.GetLastNUIDs(10)    // Last 10 messages by UID
+last10UIDs, _ := m.GetLastNUIDs(ctx, 10)    // Last 10 messages by UID
 
 // Cheaper method to retrieve the latest UID (requires RFC-4731;
 // not all servers support this — check the error).
-maxUID, _ := m.GetMaxUID()             // Highest UID only
+maxUID, _ := m.GetMaxUID(ctx)             // Highest UID only
 
 // Size-based searches
-largeUIDs, _ := m.GetUIDs("LARGER 10485760")  // Emails larger than 10MB
-smallUIDs, _ := m.GetUIDs("SMALLER 1024")     // Emails smaller than 1KB
+largeUIDs, _ := m.GetUIDs(ctx, "LARGER 10485760")  // Emails larger than 10MB
+smallUIDs, _ := m.GetUIDs(ctx, "SMALLER 1024")     // Emails smaller than 1KB
 
 // Non-ASCII searches using RFC 3501 literal syntax
 // The library automatically detects and handles literal syntax {n}
 // where n is the byte count of the following data
 
 // Search for Cyrillic text in subject (тест = 8 bytes in UTF-8)
-cyrillicUIDs, _ := m.GetUIDs("CHARSET UTF-8 Subject {8}\r\nтест")
+cyrillicUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 Subject {8}\r\nтест")
 
 // Search for Chinese text in subject (测试 = 6 bytes in UTF-8)  
-chineseUIDs, _ := m.GetUIDs("CHARSET UTF-8 Subject {6}\r\n测试")
+chineseUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 Subject {6}\r\n测试")
 
 // Search for Japanese text in body (テスト = 9 bytes in UTF-8)
-japaneseUIDs, _ := m.GetUIDs("CHARSET UTF-8 BODY {9}\r\nテスト")
+japaneseUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 BODY {9}\r\nテスト")
 
 // Search for Arabic text (اختبار = 12 bytes in UTF-8)
-arabicUIDs, _ := m.GetUIDs("CHARSET UTF-8 TEXT {12}\r\nاختبار")
+arabicUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 TEXT {12}\r\nاختبار")
 
 // Search with emoji (😀👍 = 8 bytes in UTF-8)
-emojiUIDs, _ := m.GetUIDs("CHARSET UTF-8 TEXT {8}\r\n😀👍")
+emojiUIDs, _ := m.GetUIDs(ctx, "CHARSET UTF-8 TEXT {8}\r\n😀👍")
 
 // Note: Always specify CHARSET UTF-8 for non-ASCII searches
 // The {n} syntax tells the server exactly how many bytes to expect
@@ -404,10 +413,10 @@ For complex or repeated queries, use the fluent `SearchBuilder` instead of raw s
 
 ```go
 // Simple search
-uids, _ := m.SearchUIDs(imap.Search().Unseen())
+uids, _ := m.SearchUIDs(ctx, imap.Search().Unseen())
 
 // Combine multiple criteria (AND)
-uids, _ = m.SearchUIDs(
+uids, _ = m.SearchUIDs(ctx, 
     imap.Search().
         From("boss@company.com").
         Since(time.Now().AddDate(0, 0, -7)).
@@ -416,38 +425,38 @@ uids, _ = m.SearchUIDs(
 
 // Date range
 lastMonth := time.Now().AddDate(0, -1, 0)
-uids, _ = m.SearchUIDs(
+uids, _ = m.SearchUIDs(ctx, 
     imap.Search().Since(lastMonth).Before(time.Now()).Flagged(),
 )
 
 // OR and NOT operators
-uids, _ = m.SearchUIDs(
+uids, _ = m.SearchUIDs(ctx, 
     imap.Search().Or(
         imap.Search().From("alice@example.com"),
         imap.Search().From("bob@example.com"),
     ).Unseen(),
 )
 
-uids, _ = m.SearchUIDs(
+uids, _ = m.SearchUIDs(ctx, 
     imap.Search().Not(imap.Search().From("noreply@")).Unseen(),
 )
 
 // Size filters
-uids, _ = m.SearchUIDs(imap.Search().Larger(10 * 1024 * 1024)) // > 10MB
+uids, _ = m.SearchUIDs(ctx, imap.Search().Larger(10 * 1024 * 1024)) // > 10MB
 
 // Non-ASCII text is handled automatically (CHARSET UTF-8 + literal syntax)
-uids, _ = m.SearchUIDs(imap.Search().Subject("日報"))
+uids, _ = m.SearchUIDs(ctx, imap.Search().Subject("日報"))
 
 // You can also use Build() to get the raw string for GetUIDs()
 query := imap.Search().From("alice").Unseen().Since(lastMonth).Build()
-uids, _ = m.GetUIDs(query)
+uids, _ = m.GetUIDs(ctx, query)
 ```
 
 ### 3. Fetching Email Details
 
 ```go
 // Get overview (headers only, no body) - FAST
-overviews, err := m.GetOverviews(uids...)
+overviews, err := m.GetOverviews(ctx, uids...)
 if err != nil { panic(err) }
 
 for uid, email := range overviews {
@@ -468,7 +477,7 @@ for uid, email := range overviews {
 //   Flags: [\Seen]
 
 // Get full emails with bodies - SLOWER
-emails, err := m.GetEmails(uids...)
+emails, err := m.GetEmails(ctx, uids...)
 if err != nil { panic(err) }
 
 for uid, email := range emails {
@@ -535,24 +544,24 @@ fmt.Print(email)
 ```go
 // === Moving and Copying Emails ===
 uid := 245
-err = m.MoveEmail(uid, "INBOX/Archive")
+err = m.MoveEmail(ctx, uid, "INBOX/Archive")
 if err != nil { panic(err) }
 fmt.Printf("Moved email %d to Archive\n", uid)
 
 // Copy keeps the original in the current folder
-err = m.CopyEmail(uid, "INBOX/Backup")
+err = m.CopyEmail(ctx, uid, "INBOX/Backup")
 if err != nil { panic(err) }
 fmt.Printf("Copied email %d to Backup\n", uid)
 
 // === Uploading Messages (APPEND) ===
 msg := []byte("From: me@example.com\r\nTo: you@example.com\r\nSubject: Hello\r\n\r\nMessage body")
-err = m.Append("Drafts", []string{`\Draft`, `\Seen`}, time.Now(), msg)
+err = m.Append(ctx, "Drafts", []string{`\Draft`, `\Seen`}, time.Now(), msg)
 if err != nil { panic(err) }
 fmt.Println("Uploaded draft message")
 
 // === Setting Flags ===
 // Mark as read
-err = m.MarkSeen(uid)
+err = m.MarkSeen(ctx, uid)
 if err != nil { panic(err) }
 
 // Set multiple flags at once
@@ -561,7 +570,7 @@ flags := imap.Flags{
     Flagged:  imap.FlagAdd,      // Star/flag the email
     Answered: imap.FlagRemove,   // Remove answered flag
 }
-err = m.SetFlags(uid, flags)
+err = m.SetFlags(ctx, uid, flags)
 if err != nil { panic(err) }
 
 // Custom keywords (if server supports)
@@ -572,17 +581,17 @@ flags = imap.Flags{
         "$Pending":   false,     // Remove this keyword
     },
 }
-err = m.SetFlags(uid, flags)
+err = m.SetFlags(ctx, uid, flags)
 if err != nil { panic(err) }
 
 // === Deleting Emails ===
 // Step 1: Mark as deleted (sets \Deleted flag)
-err = m.DeleteEmail(uid)
+err = m.DeleteEmail(ctx, uid)
 if err != nil { panic(err) }
 fmt.Printf("Marked email %d for deletion\n", uid)
 
 // Step 2: Expunge to permanently remove all \Deleted emails
-err = m.Expunge()
+err = m.Expunge(ctx)
 if err != nil { panic(err) }
 fmt.Println("Permanently deleted all marked emails")
 
@@ -604,8 +613,8 @@ handler := &imap.IdleHandler{
         // Example output: [EXISTS] New message at index: 343
 
         // You might want to fetch the new email:
-        // uids, _ := m.GetUIDs(fmt.Sprintf("%d", e.MessageIndex))
-        // emails, _ := m.GetEmails(uids...)
+        // uids, _ := m.GetUIDs(ctx, fmt.Sprintf("%d", e.MessageIndex))
+        // emails, _ := m.GetEmails(ctx, uids...)
     },
 
     // Email was deleted/expunged
@@ -623,7 +632,7 @@ handler := &imap.IdleHandler{
 }
 
 // Start IDLE (non-blocking, runs in background)
-err := m.StartIdle(handler)
+err := m.StartIdle(ctx, handler)
 if err != nil { panic(err) }
 
 // Your application continues running...
@@ -636,7 +645,7 @@ if err != nil { panic(err) }
 // Full example with proper lifecycle:
 func monitorInbox(m *imap.Dialer) {
     // Select the folder to monitor
-    if err := m.SelectFolder("INBOX"); err != nil {
+    if err := m.SelectFolder(ctx, "INBOX"); err != nil {
         panic(err)
     }
 
@@ -653,7 +662,7 @@ func monitorInbox(m *imap.Dialer) {
     }
 
     fmt.Println("Starting IDLE monitoring...")
-    if err := m.StartIdle(handler); err != nil {
+    if err := m.StartIdle(ctx, handler); err != nil {
         panic(err)
     }
 
@@ -678,21 +687,21 @@ func robustEmailFetch(m *imap.Dialer) {
     imap.RetryCount = 5  // Will retry failed operations 5 times
     imap.Verbose = true  // Emit debug logs while retrying commands
 
-    err := m.SelectFolder("INBOX")
+    err := m.SelectFolder(ctx, "INBOX")
     if err != nil {
         // Connection errors are automatically retried
         // This only fails after all retries are exhausted
         fmt.Printf("Failed to select folder after %d retries: %v\n", imap.RetryCount, err)
 
         // You might want to manually reconnect
-        if err := m.Reconnect(); err != nil {
+        if err := m.Reconnect(ctx); err != nil {
             fmt.Printf("Manual reconnection failed: %v\n", err)
             return
         }
     }
 
     // Fetch emails with automatic retry on network issues
-    uids, err := m.GetUIDs("UNSEEN")
+    uids, err := m.GetUIDs(ctx, "UNSEEN")
     if err != nil {
         fmt.Printf("Search failed: %v\n", err)
         return
@@ -705,7 +714,7 @@ func robustEmailFetch(m *imap.Dialer) {
     // 4. Re-select the previously selected folder
     // 5. Retry the failed command
 
-    emails, err := m.GetEmails(uids...)
+    emails, err := m.GetEmails(ctx, uids...)
     if err != nil {
         fmt.Printf("Fetch failed after retries: %v\n", err)
         return
@@ -731,7 +740,7 @@ func configureTimeouts() {
     defer m.Close()
 
     // This search will timeout after 30 seconds
-    uids, err := m.GetUIDs("ALL")
+    uids, err := m.GetUIDs(ctx, "ALL")
     if err != nil {
         fmt.Printf("Command timed out or failed: %v\n", err)
     }
@@ -768,7 +777,7 @@ func main() {
 
     // List folders
     fmt.Println("\n📁 Available folders:")
-    folders, err := m.GetFolders()
+    folders, err := m.GetFolders(ctx)
     if err != nil {
         log.Fatalf("Failed to get folders: %v", err)
     }
@@ -778,13 +787,13 @@ func main() {
 
     // Select INBOX
     fmt.Println("\n📥 Selecting INBOX...")
-    if err := m.SelectFolder("INBOX"); err != nil {
+    if err := m.SelectFolder(ctx, "INBOX"); err != nil {
         log.Fatalf("Failed to select INBOX: %v", err)
     }
 
     // Get unread emails
     fmt.Println("\n🔍 Searching for unread emails...")
-    unreadUIDs, err := m.GetUIDs("UNSEEN")
+    unreadUIDs, err := m.GetUIDs(ctx, "UNSEEN")
     if err != nil {
         log.Fatalf("Search failed: %v", err)
     }
@@ -798,7 +807,7 @@ func main() {
 
     if limit > 0 {
         fmt.Printf("\n📧 Fetching first %d unread emails...\n", limit)
-        emails, err := m.GetEmails(unreadUIDs[:limit]...)
+        emails, err := m.GetEmails(ctx, unreadUIDs[:limit]...)
         if err != nil {
             log.Fatalf("Failed to fetch emails: %v", err)
         }
@@ -826,7 +835,7 @@ func main() {
             // Mark first email as read
             if uid == unreadUIDs[0] {
                 fmt.Printf("\n✓ Marking email %d as read...\n", uid)
-                if err := m.MarkSeen(uid); err != nil {
+                if err := m.MarkSeen(ctx, uid); err != nil {
                     fmt.Printf("Failed to mark as read: %v\n", err)
                 }
             }
@@ -835,9 +844,9 @@ func main() {
 
     // Get some statistics
     fmt.Println("\n📊 Mailbox Statistics:")
-    allUIDs, _ := m.GetUIDs("ALL")
-    seenUIDs, _ := m.GetUIDs("SEEN")
-    flaggedUIDs, _ := m.GetUIDs("FLAGGED")
+    allUIDs, _ := m.GetUIDs(ctx, "ALL")
+    seenUIDs, _ := m.GetUIDs(ctx, "SEEN")
+    flaggedUIDs, _ := m.GetUIDs(ctx, "FLAGGED")
 
     fmt.Printf("  Total emails: %d\n", len(allUIDs))
     fmt.Printf("  Read emails: %d\n", len(seenUIDs))
@@ -852,7 +861,7 @@ func main() {
         },
     }
 
-    if err := m.StartIdle(handler); err == nil {
+    if err := m.StartIdle(ctx, handler); err == nil {
         time.Sleep(10 * time.Second)
         _ = m.StopIdle()
     }

--- a/append.go
+++ b/append.go
@@ -28,7 +28,7 @@ func (d *Client) waitForTaggedOK(r *bufio.Reader, tag []byte) error {
 
 		if len(line) >= taglen+3 && bytes.Equal(line[:taglen], tag) {
 			if !bytes.Equal(line[taglen+1:taglen+3], []byte("OK")) {
-				return fmt.Errorf("imap append failed: %s", dropNl(line[taglen+1:]))
+				return parseCommandError(string(tag), "APPEND", line[taglen+1:])
 			}
 			return nil
 		}
@@ -90,19 +90,33 @@ func (d *Client) Append(ctx context.Context, folder string, flags []string, date
 		return fmt.Errorf("imap append write command: %w", wrapCtxErr(ctx, err))
 	}
 
-	// Phase 2: Wait for continuation response (+)
+	// Phase 2: Wait for continuation response (+). The server may emit
+	// untagged responses (e.g. "* OK ...") first, and may reject the
+	// command outright with a tagged NO/BAD/BYE before requesting the
+	// literal — surface those as CommandError so callers can inspect
+	// response codes like [TRYCREATE] or [OVERQUOTA].
 	r := bufio.NewReader(d.conn)
-	line, err := r.ReadBytes('\n')
-	if err != nil {
-		_ = d.Close()
-		return fmt.Errorf("imap append read continuation: %w", wrapCtxErr(ctx, err))
-	}
+	taglen := len(tag)
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			_ = d.Close()
+			return fmt.Errorf("imap append read continuation: %w", wrapCtxErr(ctx, err))
+		}
 
-	if Verbose && !SkipResponses {
-		debugLog(d.ConnNum, d.Folder, "server response", "response", string(dropNl(line)))
-	}
+		if Verbose && !SkipResponses {
+			debugLog(d.ConnNum, d.Folder, "server response", "response", string(dropNl(line)))
+		}
 
-	if !bytes.HasPrefix(bytes.TrimSpace(line), []byte("+")) {
+		if bytes.HasPrefix(bytes.TrimSpace(line), []byte("+")) {
+			break
+		}
+		if len(line) >= taglen+3 && bytes.Equal(line[:taglen], tag) {
+			return parseCommandError(string(tag), "APPEND", line[taglen+1:])
+		}
+		if bytes.HasPrefix(line, []byte("* ")) {
+			continue
+		}
 		return fmt.Errorf("imap append: expected continuation (+), got: %s", dropNl(line))
 	}
 
@@ -118,9 +132,19 @@ func (d *Client) Append(ctx context.Context, folder string, flags []string, date
 		return fmt.Errorf("imap append write crlf: %w", wrapCtxErr(ctx, err))
 	}
 
-	// Phase 4: Read the tagged response
+	// Phase 4: Read the tagged response. If ctx was cancelled mid-flight
+	// the watchdog has poisoned the deadline and waitForTaggedOK will
+	// return a timeout error; close the socket so the next caller doesn't
+	// consume a tagged completion the server may still emit. Once the
+	// tagged OK has been read the APPEND is committed server-side, so we
+	// must report success even if ctx was cancelled in the meantime —
+	// otherwise a retrying caller would duplicate the message.
 	if err := d.waitForTaggedOK(r, tag); err != nil {
-		return wrapCtxErr(ctx, err)
+		if cerr := ctx.Err(); cerr != nil {
+			_ = d.Close()
+			return cerr
+		}
+		return err
 	}
 	return nil
 }

--- a/append.go
+++ b/append.go
@@ -3,6 +3,7 @@ package imap
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -12,7 +13,7 @@ import (
 
 // waitForTaggedOK reads lines from r until it finds the tagged response matching tag.
 // It returns nil if the response is OK, or an error otherwise.
-func (d *Dialer) waitForTaggedOK(r *bufio.Reader, tag []byte) error {
+func (d *Client) waitForTaggedOK(r *bufio.Reader, tag []byte) error {
 	taglen := len(tag)
 	for {
 		line, err := r.ReadBytes('\n')
@@ -49,8 +50,8 @@ func (d *Dialer) waitForTaggedOK(r *bufio.Reader, tag []byte) error {
 // Example:
 //
 //	msg := []byte("From: a@b.com\r\nTo: c@d.com\r\nSubject: Hi\r\n\r\nHello!")
-//	err := conn.Append("INBOX", []string{`\Seen`}, time.Time{}, msg)
-func (d *Dialer) Append(folder string, flags []string, date time.Time, message []byte) error {
+//	err := conn.Append(ctx, "INBOX", []string{`\Seen`}, time.Time{}, msg)
+func (d *Client) Append(ctx context.Context, folder string, flags []string, date time.Time, message []byte) error {
 	// Build the APPEND command prefix
 	flagStr := ""
 	if len(flags) > 0 {
@@ -66,10 +67,15 @@ func (d *Dialer) Append(folder string, flags []string, date time.Time, message [
 
 	tag := []byte(strings.ToUpper(xid.New().String()))
 
-	if CommandTimeout != 0 {
-		_ = d.conn.SetDeadline(time.Now().Add(CommandTimeout))
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if deadline, ok := d.deadlineFromCtx(ctx); ok {
+		_ = d.conn.SetDeadline(deadline)
 		defer func() { _ = d.conn.SetDeadline(time.Time{}) }()
 	}
+	stop := d.watchCtxCancel(ctx)
+	defer stop()
 
 	if Verbose {
 		debugLog(d.ConnNum, d.Folder, "sending command", "command", string(tag)+" "+cmd)
@@ -78,7 +84,8 @@ func (d *Dialer) Append(folder string, flags []string, date time.Time, message [
 	// Phase 1: Send the APPEND command with literal size
 	_, err := fmt.Fprintf(d.conn, "%s %s\r\n", tag, cmd)
 	if err != nil {
-		return fmt.Errorf("imap append write command: %w", err)
+		_ = d.Close()
+		return fmt.Errorf("imap append write command: %w", wrapCtxErr(ctx, err))
 	}
 
 	// Phase 2: Wait for continuation response (+)
@@ -86,7 +93,7 @@ func (d *Dialer) Append(folder string, flags []string, date time.Time, message [
 	line, err := r.ReadBytes('\n')
 	if err != nil {
 		_ = d.Close()
-		return fmt.Errorf("imap append read continuation: %w", err)
+		return fmt.Errorf("imap append read continuation: %w", wrapCtxErr(ctx, err))
 	}
 
 	if Verbose && !SkipResponses {
@@ -101,14 +108,17 @@ func (d *Dialer) Append(folder string, flags []string, date time.Time, message [
 	_, err = d.conn.Write(message)
 	if err != nil {
 		_ = d.Close()
-		return fmt.Errorf("imap append write literal: %w", err)
+		return fmt.Errorf("imap append write literal: %w", wrapCtxErr(ctx, err))
 	}
 	_, err = d.conn.Write([]byte("\r\n"))
 	if err != nil {
 		_ = d.Close()
-		return fmt.Errorf("imap append write crlf: %w", err)
+		return fmt.Errorf("imap append write crlf: %w", wrapCtxErr(ctx, err))
 	}
 
 	// Phase 4: Read the tagged response
-	return d.waitForTaggedOK(r, tag)
+	if err := d.waitForTaggedOK(r, tag); err != nil {
+		return wrapCtxErr(ctx, err)
+	}
+	return nil
 }

--- a/append.go
+++ b/append.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/xid"
@@ -47,6 +48,14 @@ func (d *Client) waitForTaggedOK(r *bufio.Reader, tag []byte) error {
 // two-phase literal transfer. A partial send cannot be safely retried without
 // risking duplicate messages.
 //
+// Context semantics: ctx bounds phases 1–3 (sending the command, waiting for
+// the continuation, and streaming the literal). Once the literal has been
+// fully transmitted, the server may commit the message at any moment, so the
+// final tagged-response wait ignores ctx cancellation in favor of a short
+// cleanup deadline. This means a caller that cancels ctx after the literal
+// is on the wire can still block briefly while the outcome is observed —
+// returning early would risk duplicate mail on retry.
+//
 // Example:
 //
 //	msg := []byte("From: a@b.com\r\nTo: c@d.com\r\nSubject: Hi\r\n\r\nHello!")
@@ -70,7 +79,9 @@ func (d *Client) Append(ctx context.Context, folder string, flags []string, date
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	stop := d.watchCtxCancel(ctx)
+	var stopOnce sync.Once
+	rawStop := d.watchCtxCancel(ctx)
+	stop := func() { stopOnce.Do(rawStop) }
 	defer func() {
 		stop()
 		_ = d.conn.SetDeadline(time.Time{})
@@ -132,19 +143,20 @@ func (d *Client) Append(ctx context.Context, folder string, flags []string, date
 		return fmt.Errorf("imap append write crlf: %w", wrapCtxErr(ctx, err))
 	}
 
-	// Phase 4: Read the tagged response. If ctx was cancelled mid-flight
-	// the watchdog has poisoned the deadline and waitForTaggedOK will
-	// return a timeout error; close the socket so the next caller doesn't
-	// consume a tagged completion the server may still emit. Once the
-	// tagged OK has been read the APPEND is committed server-side, so we
-	// must report success even if ctx was cancelled in the meantime —
-	// otherwise a retrying caller would duplicate the message.
-	if err := d.waitForTaggedOK(r, tag); err != nil {
-		if cerr := ctx.Err(); cerr != nil {
-			_ = d.Close()
-			return cerr
-		}
-		return err
+	// Phase 4: Read the tagged response. Once the literal has been fully
+	// transmitted the server may commit the message at any moment, so
+	// returning ctx.Err() here risks duplicate mail if the caller retries.
+	// Detach cancellation and apply a bounded deadline so we can reliably
+	// observe OK/NO and report the authoritative outcome. The deadline is
+	// the shorter of the caller's CommandTimeout (when configured) and the
+	// default cleanup budget — this preserves the per-command-timeout
+	// contract while still capping how long we wait for a stalled server.
+	stop()
+	_ = d.conn.SetDeadline(time.Time{})
+	cleanupBudget := 30 * time.Second
+	if t := d.effectiveCommandTimeout(); t > 0 && t < cleanupBudget {
+		cleanupBudget = t
 	}
-	return nil
+	_ = d.conn.SetDeadline(time.Now().Add(cleanupBudget))
+	return d.waitForTaggedOK(r, tag)
 }

--- a/append.go
+++ b/append.go
@@ -63,7 +63,7 @@ func (d *Client) Append(ctx context.Context, folder string, flags []string, date
 	}
 
 	cmd := fmt.Sprintf(`APPEND "%s"%s%s {%d}`,
-		AddSlashes.Replace(folder), flagStr, dateStr, len(message))
+		addSlashes.Replace(folder), flagStr, dateStr, len(message))
 
 	tag := []byte(strings.ToUpper(xid.New().String()))
 

--- a/append.go
+++ b/append.go
@@ -70,12 +70,14 @@ func (d *Client) Append(ctx context.Context, folder string, flags []string, date
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	stop := d.watchCtxCancel(ctx)
+	defer func() {
+		stop()
+		_ = d.conn.SetDeadline(time.Time{})
+	}()
 	if deadline, ok := d.deadlineFromCtx(ctx); ok {
 		_ = d.conn.SetDeadline(deadline)
-		defer func() { _ = d.conn.SetDeadline(time.Time{}) }()
 	}
-	stop := d.watchCtxCancel(ctx)
-	defer stop()
 
 	if Verbose {
 		debugLog(d.ConnNum, d.Folder, "sending command", "command", string(tag)+" "+cmd)

--- a/auth.go
+++ b/auth.go
@@ -18,6 +18,6 @@ func (d *Client) Authenticate(ctx context.Context, user string, accessToken stri
 // Login performs LOGIN authentication using username and password.
 func (d *Client) Login(ctx context.Context, username string, password string) error {
 	// Don't retry authentication - auth failures should not trigger reconnection
-	_, err := d.Exec(ctx, fmt.Sprintf(`LOGIN "%s" "%s"`, AddSlashes.Replace(username), AddSlashes.Replace(password)), false, 0, nil)
+	_, err := d.Exec(ctx, fmt.Sprintf(`LOGIN "%s" "%s"`, addSlashes.Replace(username), addSlashes.Replace(password)), false, 0, nil)
 	return err
 }

--- a/auth.go
+++ b/auth.go
@@ -1,22 +1,23 @@
 package imap
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sqs/go-xoauth2"
 )
 
-// Authenticate performs XOAUTH2 authentication using an access token
-func (d *Dialer) Authenticate(user string, accessToken string) (err error) {
+// Authenticate performs XOAUTH2 authentication using an access token.
+func (d *Client) Authenticate(ctx context.Context, user string, accessToken string) error {
 	b64 := xoauth2.XOAuth2String(user, accessToken)
 	// Don't retry authentication - auth failures should not trigger reconnection
-	_, err = d.Exec(fmt.Sprintf("AUTHENTICATE XOAUTH2 %s", b64), false, 0, nil)
+	_, err := d.Exec(ctx, fmt.Sprintf("AUTHENTICATE XOAUTH2 %s", b64), false, 0, nil)
 	return err
 }
 
-// Login performs LOGIN authentication using username and password
-func (d *Dialer) Login(username string, password string) (err error) {
+// Login performs LOGIN authentication using username and password.
+func (d *Client) Login(ctx context.Context, username string, password string) error {
 	// Don't retry authentication - auth failures should not trigger reconnection
-	_, err = d.Exec(fmt.Sprintf(`LOGIN "%s" "%s"`, AddSlashes.Replace(username), AddSlashes.Replace(password)), false, 0, nil)
+	_, err := d.Exec(ctx, fmt.Sprintf(`LOGIN "%s" "%s"`, AddSlashes.Replace(username), AddSlashes.Replace(password)), false, 0, nil)
 	return err
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -31,6 +31,11 @@ type mockIMAPServer struct {
 	responses      map[string]string
 	failCommands   map[string]bool // commands that should return NO (keyed by uppercase command name)
 	tlsConfig      *tls.Config
+	// handler, if set, is invoked before the default command switch.
+	// Return true to indicate the command was handled (and the default
+	// switch should be skipped). The handler must write both any untagged
+	// responses and the tagged completion (with Flush).
+	handler func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool
 }
 
 func newMockIMAPServer(validUser, validPass string) (*mockIMAPServer, error) {
@@ -101,6 +106,13 @@ func (s *mockIMAPServer) handleConnection(conn net.Conn) {
 
 		tag := parts[0]
 		command := strings.ToUpper(parts[1])
+
+		if s.handler != nil {
+			if s.handler(tag, line, reader, writer) {
+				writer.Flush()
+				continue
+			}
+		}
 
 		switch command {
 		case "LOGIN":

--- a/auth_test.go
+++ b/auth_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 )
 
+
 type mockIMAPServer struct {
 	listener       net.Listener
 	address        string
@@ -404,11 +405,11 @@ func TestReconnectWithBadCredentials(t *testing.T) {
 	defer d.Close()
 
 	// Change password to simulate bad credentials on reconnect
-	d.Password = "wrongpass"
+	d.SetAuth(PasswordAuth{Username: "testuser", Password: "wrongpass"})
 	server.ResetAuthAttempts()
 
 	// Attempt reconnect with bad credentials
-	err = d.Reconnect()
+	err = d.Reconnect(ctx)
 	if err == nil {
 		t.Error("Expected reconnect to fail with bad credentials")
 	}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+ignore:
+  - "examples/**/*"

--- a/conn.go
+++ b/conn.go
@@ -347,8 +347,7 @@ func (d *Client) Reconnect(ctx context.Context) error {
 
 	if d.auth != nil {
 		if err := d.auth.authenticate(ctx, d); err != nil {
-			_ = d.conn.Close()
-			d.Connected = false
+			_ = d.Close()
 			return fmt.Errorf("imap reconnect auth: %w", err)
 		}
 	}
@@ -356,14 +355,12 @@ func (d *Client) Reconnect(ctx context.Context) error {
 	if d.Folder != "" {
 		if d.ReadOnly {
 			if err := d.ExamineFolder(ctx, d.Folder); err != nil {
-				_ = d.conn.Close()
-				d.Connected = false
+				_ = d.Close()
 				return fmt.Errorf("imap reconnect examine: %w", err)
 			}
 		} else {
 			if err := d.SelectFolder(ctx, d.Folder); err != nil {
-				_ = d.conn.Close()
-				d.Connected = false
+				_ = d.Close()
 				return fmt.Errorf("imap reconnect select: %w", err)
 			}
 		}

--- a/conn.go
+++ b/conn.go
@@ -46,8 +46,16 @@ func credsFromAuth(a Authenticator) (string, string) {
 	switch v := a.(type) {
 	case PasswordAuth:
 		return v.Username, v.Password
+	case *PasswordAuth:
+		if v != nil {
+			return v.Username, v.Password
+		}
 	case XOAuth2:
 		return v.Username, v.AccessToken
+	case *XOAuth2:
+		if v != nil {
+			return v.Username, v.AccessToken
+		}
 	}
 	return "", ""
 }
@@ -92,14 +100,7 @@ func (d *Client) SetAuth(a Authenticator) {
 	// Update stored opts so Clone re-dials with the current credentials.
 	d.opts.Auth = a
 	// Keep username/password mirrored for diagnostic/log sanitization.
-	switch v := a.(type) {
-	case PasswordAuth:
-		d.Username = v.Username
-		d.password = v.Password
-	case XOAuth2:
-		d.Username = v.Username
-		d.password = v.AccessToken
-	}
+	d.Username, d.password = credsFromAuth(a)
 }
 
 // Dialer is a deprecated alias for Client retained so that existing callers
@@ -302,7 +303,7 @@ func (d *Client) Clone(ctx context.Context) (*Client, error) {
 			err = d2.SelectFolder(ctx, d.Folder)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("imap clone: %s", err)
+			return nil, fmt.Errorf("imap clone: %w", err)
 		}
 	}
 	return d2, nil
@@ -314,7 +315,7 @@ func (d *Client) Close() (err error) {
 		debugLog(d.ConnNum, d.Folder, "closing connection")
 		err = d.conn.Close()
 		if err != nil {
-			return fmt.Errorf("imap close: %s", err)
+			return fmt.Errorf("imap close: %w", err)
 		}
 		d.Connected = false
 	}
@@ -338,7 +339,7 @@ func (d *Client) Reconnect(ctx context.Context) error {
 	}
 	conn, err := dialHost(ctx, dialOpts)
 	if err != nil {
-		return fmt.Errorf("imap reconnect dial: %s", err)
+		return fmt.Errorf("imap reconnect dial: %w", err)
 	}
 	d.conn = conn
 	d.Connected = true
@@ -347,18 +348,18 @@ func (d *Client) Reconnect(ctx context.Context) error {
 		if err := d.auth.authenticate(ctx, d); err != nil {
 			_ = d.conn.Close()
 			d.Connected = false
-			return fmt.Errorf("imap reconnect auth: %s", err)
+			return fmt.Errorf("imap reconnect auth: %w", err)
 		}
 	}
 
 	if d.Folder != "" {
 		if d.ReadOnly {
 			if err := d.ExamineFolder(ctx, d.Folder); err != nil {
-				return fmt.Errorf("imap reconnect examine: %s", err)
+				return fmt.Errorf("imap reconnect examine: %w", err)
 			}
 		} else {
 			if err := d.SelectFolder(ctx, d.Folder); err != nil {
-				return fmt.Errorf("imap reconnect select: %s", err)
+				return fmt.Errorf("imap reconnect select: %w", err)
 			}
 		}
 	}

--- a/conn.go
+++ b/conn.go
@@ -31,6 +31,7 @@ type Client struct {
 	stateMu   sync.Mutex
 	idleStop  chan struct{}
 	idleDone  chan struct{}
+	closeMu   sync.Mutex
 	// auth is retained so Reconnect can re-authenticate using the same
 	// method and credentials the caller originally supplied.
 	auth Authenticator
@@ -310,8 +311,11 @@ func (d *Client) Clone(ctx context.Context) (*Client, error) {
 	return d2, nil
 }
 
-// Close closes the IMAP connection.
+// Close closes the IMAP connection. Safe to call concurrently and multiple
+// times; subsequent calls after the first successful close are no-ops.
 func (d *Client) Close() (err error) {
+	d.closeMu.Lock()
+	defer d.closeMu.Unlock()
 	if d.Connected {
 		debugLog(d.ConnNum, d.Folder, "closing connection")
 		err = d.conn.Close()

--- a/conn.go
+++ b/conn.go
@@ -1,13 +1,14 @@
 package imap
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
 	"sync"
-
-	retry "github.com/StirlingMarketingGroup/go-retry"
+	"time"
 )
 
 var (
@@ -15,13 +16,13 @@ var (
 	nextConnNumMutex = sync.RWMutex{}
 )
 
-// Dialer represents an IMAP connection
-type Dialer struct {
+// Client represents an IMAP connection.
+type Client struct {
 	conn      *tls.Conn
 	Folder    string
 	ReadOnly  bool
 	Username  string
-	Password  string
+	password  string
 	Host      string
 	Port      int
 	Connected bool
@@ -30,182 +31,287 @@ type Dialer struct {
 	stateMu   sync.Mutex
 	idleStop  chan struct{}
 	idleDone  chan struct{}
-	// useXOAUTH2 indicates whether XOAUTH2 authentication should be used
-	// on (re)connection instead of LOGIN. It is set by NewWithOAuth2.
-	useXOAUTH2 bool
+	// auth is retained so Reconnect can re-authenticate using the same
+	// method and credentials the caller originally supplied.
+	auth Authenticator
+	// opts is the original Dial options (minus Auth, which lives in auth).
+	// Retained so Reconnect and Clone can reuse custom TLSConfig, Dialer,
+	// timeouts, and retry settings.
+	opts Options
 }
 
-// dialHost establishes a TLS connection to the IMAP server
-func dialHost(host string, port int) (*tls.Conn, error) {
-	dialer := &net.Dialer{Timeout: DialTimeout}
-	var cfg *tls.Config
-	if TLSSkipVerify {
-		cfg = &tls.Config{InsecureSkipVerify: true}
+// credsFromAuth extracts a (username, secret) pair from a known
+// Authenticator for log sanitization. Unknown types yield empty strings.
+func credsFromAuth(a Authenticator) (string, string) {
+	switch v := a.(type) {
+	case PasswordAuth:
+		return v.Username, v.Password
+	case XOAuth2:
+		return v.Username, v.AccessToken
 	}
-	return tls.DialWithDialer(dialer, "tcp", host+":"+strconv.Itoa(port), cfg)
+	return "", ""
 }
 
-// NewWithOAuth2 creates a new IMAP connection using OAuth2 authentication
-func NewWithOAuth2(username string, accessToken string, host string, port int) (d *Dialer, err error) {
-	nextConnNumMutex.RLock()
-	connNum := nextConnNum
-	nextConnNumMutex.RUnlock()
-
-	nextConnNumMutex.Lock()
-	nextConnNum++
-	nextConnNumMutex.Unlock()
-
-	// Retry only the connection establishment, not authentication
-	err = retry.Retry(func() error {
-		if Verbose {
-			debugLog(connNum, "", "establishing connection", "host", host, "port", port, "auth", "xoauth2")
-		}
-		var conn *tls.Conn
-		conn, err = dialHost(host, port)
-		if err != nil {
-			if Verbose {
-				debugLog(connNum, "", "connection attempt failed", "error", err)
-			}
-			return err
-		}
-		d = &Dialer{
-			conn:       conn,
-			Username:   username,
-			Password:   accessToken,
-			Host:       host,
-			Port:       port,
-			Connected:  true,
-			ConnNum:    connNum,
-			useXOAUTH2: true,
-		}
-		return nil
-	}, RetryCount, func(err error) error {
-		if Verbose {
-			debugLog(connNum, "", "connection retry scheduled")
-			if d != nil && d.conn != nil {
-				_ = d.conn.Close()
-			}
-		}
-		return nil
-	}, func() error {
-		if Verbose {
-			debugLog(connNum, "", "retrying connection")
-		}
-		return nil
-	})
-	if err != nil {
-		warnLog(connNum, "", "failed to establish connection", "error", err)
-		if d != nil && d.conn != nil {
-			_ = d.conn.Close()
-		}
-		return nil, err
+// effectiveRetryCount returns the retry count for this client. A positive
+// Options.RetryCount is used as-is. A negative value explicitly disables
+// retries for this client, regardless of the package-level RetryCount. A
+// zero value falls back to the package-level RetryCount.
+func (d *Client) effectiveRetryCount() int {
+	switch {
+	case d.opts.RetryCount > 0:
+		return d.opts.RetryCount
+	case d.opts.RetryCount < 0:
+		return 0
+	default:
+		return RetryCount
 	}
-
-	// Authenticate after connection is established - no retry for auth failures
-	err = d.Authenticate(username, accessToken)
-	if err != nil {
-		errorLog(connNum, "", "authentication failed", "error", err)
-		_ = d.Close()
-		return nil, err
-	}
-
-	return d, nil
 }
 
-// New creates a new IMAP connection using username/password authentication
-func New(username string, password string, host string, port int) (d *Dialer, err error) {
-	nextConnNumMutex.RLock()
-	connNum := nextConnNum
-	nextConnNumMutex.RUnlock()
-
-	nextConnNumMutex.Lock()
-	nextConnNum++
-	nextConnNumMutex.Unlock()
-
-	// Retry only the connection establishment, not authentication
-	err = retry.Retry(func() error {
-		if Verbose {
-			debugLog(connNum, "", "establishing connection", "host", host, "port", port, "auth", "login")
-		}
-		var conn *tls.Conn
-		conn, err = dialHost(host, port)
-		if err != nil {
-			if Verbose {
-				debugLog(connNum, "", "connection attempt failed", "error", err)
-			}
-			return err
-		}
-		d = &Dialer{
-			conn:       conn,
-			Username:   username,
-			Password:   password,
-			Host:       host,
-			Port:       port,
-			Connected:  true,
-			ConnNum:    connNum,
-			useXOAUTH2: false,
-		}
-		return nil
-	}, RetryCount, func(err error) error {
-		if Verbose {
-			debugLog(connNum, "", "connection retry scheduled")
-			if d != nil && d.conn != nil {
-				_ = d.conn.Close()
-			}
-		}
-		return nil
-	}, func() error {
-		if Verbose {
-			debugLog(connNum, "", "retrying connection")
-		}
-		return nil
-	})
-	if err != nil {
-		warnLog(connNum, "", "failed to establish connection", "error", err)
-		if d != nil && d.conn != nil {
-			_ = d.conn.Close()
-		}
-		return nil, err
+// effectiveCommandTimeout returns the per-command deadline for this client.
+// A positive Options.CommandTimeout is used as-is. A negative value
+// explicitly disables the deadline for this client, regardless of the
+// package-level CommandTimeout. A zero value falls back to the package-level
+// CommandTimeout.
+func (d *Client) effectiveCommandTimeout() time.Duration {
+	switch {
+	case d.opts.CommandTimeout > 0:
+		return d.opts.CommandTimeout
+	case d.opts.CommandTimeout < 0:
+		return 0
+	default:
+		return CommandTimeout
 	}
-
-	// Authenticate after connection is established - no retry for auth failures
-	err = d.Login(username, password)
-	if err != nil {
-		errorLog(connNum, "", "authentication failed", "error", err)
-		_ = d.Close()
-		return nil, err
-	}
-
-	return d, nil
 }
 
-// Clone creates a copy of the dialer with the same configuration
-func (d *Dialer) Clone() (d2 *Dialer, err error) {
-	if d.useXOAUTH2 {
-		d2, err = NewWithOAuth2(d.Username, d.Password, d.Host, d.Port)
+// SetAuth replaces the client's authenticator. Use this to rotate
+// credentials or refresh an OAuth2 access token on a long-lived client;
+// subsequent Reconnect and Clone calls will use the new authenticator.
+// SetAuth does not itself re-authenticate the open connection.
+func (d *Client) SetAuth(a Authenticator) {
+	d.auth = a
+	// Update stored opts so Clone re-dials with the current credentials.
+	d.opts.Auth = a
+	// Keep username/password mirrored for diagnostic/log sanitization.
+	switch v := a.(type) {
+	case PasswordAuth:
+		d.Username = v.Username
+		d.password = v.Password
+	case XOAuth2:
+		d.Username = v.Username
+		d.password = v.AccessToken
+	}
+}
+
+// Dialer is a deprecated alias for Client retained so that existing callers
+// compile against the v1 API without immediate changes.
+//
+// Deprecated: use Client. Will be removed in v2.
+type Dialer = Client
+
+// dialHost establishes a TLS connection to the IMAP server using the
+// supplied options. DialTimeout, when set, bounds both the TCP connect and
+// the TLS handshake (matching the prior tls.DialWithDialer behavior).
+func dialHost(ctx context.Context, opts Options) (*tls.Conn, error) {
+	if opts.DialTimeout > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.DialTimeout)
+			defer cancel()
+		}
+	}
+	address := opts.Host + ":" + strconv.Itoa(opts.Port)
+
+	// Build the TLS config: clone the caller's config so we don't mutate it,
+	// and fill in ServerName from Host when the caller didn't set one so
+	// hostname verification still works. Match the old tls.DialWithDialer
+	// behavior.
+	var tlsCfg *tls.Config
+	if opts.TLSConfig != nil {
+		tlsCfg = opts.TLSConfig.Clone()
 	} else {
-		d2, err = New(d.Username, d.Password, d.Host, d.Port)
+		tlsCfg = &tls.Config{}
 	}
-	// d2.Verbose = d1.Verbose
+	if tlsCfg.ServerName == "" {
+		tlsCfg.ServerName = opts.Host
+	}
+	if TLSSkipVerify {
+		tlsCfg.InsecureSkipVerify = true
+	}
+
+	var rawConn net.Conn
+	var err error
+	if opts.Dialer != nil {
+		rawConn, err = opts.Dialer.DialContext(ctx, "tcp", address)
+	} else {
+		d := &net.Dialer{Timeout: opts.DialTimeout}
+		rawConn, err = d.DialContext(ctx, "tcp", address)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConn := tls.Client(rawConn, tlsCfg)
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = tlsConn.SetDeadline(deadline)
+	}
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		_ = rawConn.Close()
+		return nil, err
+	}
+	_ = tlsConn.SetDeadline(time.Time{})
+	return tlsConn, nil
+}
+
+// Dial establishes a new IMAP connection using the supplied options and
+// authenticates with opts.Auth. The returned Client is ready to issue
+// commands.
+func Dial(ctx context.Context, opts Options) (*Client, error) {
+	if opts.Host == "" {
+		return nil, errors.New("imap: Options.Host is required")
+	}
+	if opts.Auth == nil {
+		return nil, errors.New("imap: Options.Auth is required")
+	}
+	if opts.Port == 0 {
+		opts.Port = 993
+	}
+
+	nextConnNumMutex.Lock()
+	connNum := nextConnNum
+	nextConnNum++
+	nextConnNumMutex.Unlock()
+
+	// Resolve retry count:
+	//   positive = use as-is
+	//   negative = explicitly disable (single attempt)
+	//   zero     = fall back to the package-level RetryCount
+	retryCount := opts.RetryCount
+	switch {
+	case retryCount > 0:
+	case retryCount < 0:
+		retryCount = 0
+	default:
+		retryCount = RetryCount
+	}
+
+	// Context-aware retry loop. Unlike retry.Retry which has its own
+	// uninterruptible sleep, this loop honors ctx during backoff so
+	// cancellation returns promptly.
+	var c *Client
+	var dialErr error
+	for attempt := 0; attempt <= retryCount; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if attempt > 0 {
+			debugLog(connNum, "", "retrying connection")
+			backoff := min(time.Duration(attempt*250)*time.Millisecond, 3*time.Second)
+			t := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				t.Stop()
+				return nil, ctx.Err()
+			case <-t.C:
+			}
+		}
+
+		debugLog(connNum, "", "establishing connection", "host", opts.Host, "port", opts.Port)
+		conn, err := dialHost(ctx, opts)
+		if err != nil {
+			debugLog(connNum, "", "connection attempt failed", "error", err)
+			dialErr = err
+			continue
+		}
+		username, password := credsFromAuth(opts.Auth)
+		c = &Client{
+			conn:      conn,
+			Username:  username,
+			password:  password,
+			Host:      opts.Host,
+			Port:      opts.Port,
+			Connected: true,
+			ConnNum:   connNum,
+			auth:      opts.Auth,
+			opts:      opts,
+		}
+		dialErr = nil
+		break
+	}
+	if dialErr != nil || c == nil {
+		warnLog(connNum, "", "failed to establish connection", "error", dialErr)
+		return nil, dialErr
+	}
+
+	if err := opts.Auth.authenticate(ctx, c); err != nil {
+		errorLog(connNum, "", "authentication failed", "error", err)
+		_ = c.Close()
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// legacyOptions builds Options for the deprecated constructors. Only
+// DialTimeout is snapshot at construction time (it's used once during the
+// initial dial). CommandTimeout and RetryCount are intentionally left zero
+// so that effectiveCommandTimeout and effectiveRetryCount read the
+// package-level globals live on every command — preserving the pre-v1
+// behavior where mutating imap.CommandTimeout or imap.RetryCount after
+// construction affected subsequent operations.
+func legacyOptions(host string, port int, auth Authenticator) Options {
+	return Options{
+		Host:        host,
+		Port:        port,
+		Auth:        auth,
+		DialTimeout: DialTimeout,
+	}
+}
+
+// New creates a new IMAP connection using LOGIN authentication.
+//
+// Deprecated: use Dial with PasswordAuth. Will be removed in v2.
+func New(username, password, host string, port int) (*Client, error) {
+	return Dial(context.Background(), legacyOptions(host, port,
+		PasswordAuth{Username: username, Password: password}))
+}
+
+// NewWithOAuth2 creates a new IMAP connection using XOAUTH2 authentication.
+//
+// Deprecated: use Dial with XOAuth2. Will be removed in v2.
+func NewWithOAuth2(username, accessToken, host string, port int) (*Client, error) {
+	return Dial(context.Background(), legacyOptions(host, port,
+		XOAuth2{Username: username, AccessToken: accessToken}))
+}
+
+// Clone creates a copy of the client with the same configuration, reusing
+// the original Dial options (including TLSConfig, Dialer, and timeouts) and
+// authentication method. Runtime changes to Host or Port are honored so
+// Clone and Reconnect target the same endpoint.
+func (d *Client) Clone(ctx context.Context) (*Client, error) {
+	dialOpts := d.opts
+	dialOpts.Host = d.Host
+	dialOpts.Port = d.Port
+	d2, err := Dial(ctx, dialOpts)
+	if err != nil {
+		return nil, err
+	}
 	if d.Folder != "" {
 		if d.ReadOnly {
-			err = d2.ExamineFolder(d.Folder)
+			err = d2.ExamineFolder(ctx, d.Folder)
 		} else {
-			err = d2.SelectFolder(d.Folder)
+			err = d2.SelectFolder(ctx, d.Folder)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("imap clone: %s", err)
 		}
 	}
-	return d2, err
+	return d2, nil
 }
 
-// Close closes the IMAP connection
-func (d *Dialer) Close() (err error) {
+// Close closes the IMAP connection.
+func (d *Client) Close() (err error) {
 	if d.Connected {
-		if Verbose {
-			debugLog(d.ConnNum, d.Folder, "closing connection")
-		}
+		debugLog(d.ConnNum, d.Folder, "closing connection")
 		err = d.conn.Close()
 		if err != nil {
 			return fmt.Errorf("imap close: %s", err)
@@ -215,44 +321,43 @@ func (d *Dialer) Close() (err error) {
 	return err
 }
 
-// Reconnect closes and reopens the IMAP connection with re-authentication
-func (d *Dialer) Reconnect() (err error) {
+// Reconnect closes and reopens the IMAP connection using the client's
+// original Dial options, re-authenticates, and restores any selected folder.
+func (d *Client) Reconnect(ctx context.Context) error {
 	_ = d.Close()
-	if Verbose {
-		debugLog(d.ConnNum, d.Folder, "reopening connection")
-	}
+	debugLog(d.ConnNum, d.Folder, "reopening connection")
 
-	conn, err := dialHost(d.Host, d.Port)
+	// Reuse the original dial options so custom TLSConfig, Dialer, and
+	// DialTimeout survive reconnection. Fields on the Client (Host/Port)
+	// take precedence in case they were updated after Dial.
+	dialOpts := d.opts
+	dialOpts.Host = d.Host
+	dialOpts.Port = d.Port
+	if dialOpts.DialTimeout == 0 {
+		dialOpts.DialTimeout = DialTimeout
+	}
+	conn, err := dialHost(ctx, dialOpts)
 	if err != nil {
 		return fmt.Errorf("imap reconnect dial: %s", err)
 	}
 	d.conn = conn
 	d.Connected = true
 
-	// Re-authenticate using the original method
-	if d.useXOAUTH2 {
-		if err := d.Authenticate(d.Username, d.Password); err != nil {
-			// Best effort cleanup on failure
+	if d.auth != nil {
+		if err := d.auth.authenticate(ctx, d); err != nil {
 			_ = d.conn.Close()
 			d.Connected = false
-			return fmt.Errorf("imap reconnect auth xoauth2: %s", err)
-		}
-	} else {
-		if err := d.Login(d.Username, d.Password); err != nil {
-			_ = d.conn.Close()
-			d.Connected = false
-			return fmt.Errorf("imap reconnect login: %s", err)
+			return fmt.Errorf("imap reconnect auth: %s", err)
 		}
 	}
 
-	// Restore selected folder state if any
 	if d.Folder != "" {
 		if d.ReadOnly {
-			if err := d.ExamineFolder(d.Folder); err != nil {
+			if err := d.ExamineFolder(ctx, d.Folder); err != nil {
 				return fmt.Errorf("imap reconnect examine: %s", err)
 			}
 		} else {
-			if err := d.SelectFolder(d.Folder); err != nil {
+			if err := d.SelectFolder(ctx, d.Folder); err != nil {
 				return fmt.Errorf("imap reconnect select: %s", err)
 			}
 		}

--- a/conn.go
+++ b/conn.go
@@ -27,7 +27,7 @@ type Client struct {
 	Port      int
 	Connected bool
 	ConnNum   int
-	state     int
+	state     State
 	stateMu   sync.Mutex
 	idleStop  chan struct{}
 	idleDone  chan struct{}
@@ -303,6 +303,7 @@ func (d *Client) Clone(ctx context.Context) (*Client, error) {
 			err = d2.SelectFolder(ctx, d.Folder)
 		}
 		if err != nil {
+			_ = d2.Close()
 			return nil, fmt.Errorf("imap clone: %w", err)
 		}
 	}
@@ -355,10 +356,14 @@ func (d *Client) Reconnect(ctx context.Context) error {
 	if d.Folder != "" {
 		if d.ReadOnly {
 			if err := d.ExamineFolder(ctx, d.Folder); err != nil {
+				_ = d.conn.Close()
+				d.Connected = false
 				return fmt.Errorf("imap reconnect examine: %w", err)
 			}
 		} else {
 			if err := d.SelectFolder(ctx, d.Folder); err != nil {
+				_ = d.conn.Close()
+				d.Connected = false
 				return fmt.Errorf("imap reconnect select: %w", err)
 			}
 		}

--- a/conn_coverage_test.go
+++ b/conn_coverage_test.go
@@ -1,0 +1,225 @@
+package imap
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCredsFromAuth(t *testing.T) {
+	cases := []struct {
+		name   string
+		auth   Authenticator
+		user   string
+		secret string
+	}{
+		{"PasswordAuth-value", PasswordAuth{Username: "u1", Password: "p1"}, "u1", "p1"},
+		{"PasswordAuth-ptr", &PasswordAuth{Username: "u2", Password: "p2"}, "u2", "p2"},
+		{"PasswordAuth-nil-ptr", (*PasswordAuth)(nil), "", ""},
+		{"XOAuth2-value", XOAuth2{Username: "u3", AccessToken: "t3"}, "u3", "t3"},
+		{"XOAuth2-ptr", &XOAuth2{Username: "u4", AccessToken: "t4"}, "u4", "t4"},
+		{"XOAuth2-nil-ptr", (*XOAuth2)(nil), "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			u, s := credsFromAuth(c.auth)
+			if u != c.user || s != c.secret {
+				t.Errorf("got (%q,%q), want (%q,%q)", u, s, c.user, c.secret)
+			}
+		})
+	}
+}
+
+func TestEffectiveRetryCount(t *testing.T) {
+	origPkg := RetryCount
+	defer func() { RetryCount = origPkg }()
+
+	RetryCount = 7
+	cases := []struct {
+		name string
+		opts Options
+		want int
+	}{
+		{"positive uses opts", Options{RetryCount: 3}, 3},
+		{"negative disables", Options{RetryCount: -1}, 0},
+		{"zero falls back to pkg", Options{}, 7},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := &Client{opts: c.opts}
+			if got := d.effectiveRetryCount(); got != c.want {
+				t.Errorf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveCommandTimeout(t *testing.T) {
+	origPkg := CommandTimeout
+	defer func() { CommandTimeout = origPkg }()
+
+	CommandTimeout = 99
+	d := &Client{opts: Options{CommandTimeout: 10}}
+	if got := d.effectiveCommandTimeout(); got != 10 {
+		t.Errorf("positive: got %d", got)
+	}
+	d.opts.CommandTimeout = -1
+	if got := d.effectiveCommandTimeout(); got != 0 {
+		t.Errorf("negative: got %d", got)
+	}
+	d.opts.CommandTimeout = 0
+	if got := d.effectiveCommandTimeout(); got != 99 {
+		t.Errorf("zero: got %d", got)
+	}
+}
+
+func TestClone(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		if strings.HasPrefix(upper, tag+" SELECT ") || strings.HasPrefix(upper, tag+" EXAMINE ") {
+			w.WriteString("* 0 EXISTS\r\n* 0 RECENT\r\n")
+			w.WriteString(tag + " OK completed\r\n")
+			return true
+		}
+		return false
+	}
+	if err := d.SelectFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("SelectFolder: %v", err)
+	}
+	d2, err := d.Clone(context.Background())
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer d2.Close()
+	if d2.Folder != "INBOX" {
+		t.Errorf("cloned folder: %q", d2.Folder)
+	}
+	if d2.ReadOnly {
+		t.Error("cloned ReadOnly should match origin (false)")
+	}
+}
+
+func TestCloneReadOnly(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		if strings.HasPrefix(upper, tag+" SELECT ") || strings.HasPrefix(upper, tag+" EXAMINE ") {
+			w.WriteString("* 0 EXISTS\r\n* 0 RECENT\r\n")
+			w.WriteString(tag + " OK completed\r\n")
+			return true
+		}
+		return false
+	}
+	if err := d.ExamineFolder(context.Background(), "Sent"); err != nil {
+		t.Fatalf("ExamineFolder: %v", err)
+	}
+	d2, err := d.Clone(context.Background())
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer d2.Close()
+	if !d2.ReadOnly {
+		t.Error("cloned ReadOnly should match origin (true)")
+	}
+}
+
+func TestCloneNoFolder(t *testing.T) {
+	d, _ := withMockClient(t)
+	d2, err := d.Clone(context.Background())
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer d2.Close()
+	if d2.Folder != "" {
+		t.Errorf("want empty folder, got %q", d2.Folder)
+	}
+}
+
+func TestWrapCtxErr(t *testing.T) {
+	if wrapCtxErr(context.Background(), nil) != nil {
+		t.Error("nil err should stay nil")
+	}
+	other := errors.New("io error")
+	if got := wrapCtxErr(context.Background(), other); got != other {
+		t.Errorf("live ctx: want original, got %v", got)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := wrapCtxErr(ctx, other); !errors.Is(got, context.Canceled) {
+		t.Errorf("cancelled ctx: want ctx.Err, got %v", got)
+	}
+}
+
+func TestSanitizeCommand(t *testing.T) {
+	cases := []struct {
+		name   string
+		cmd    string
+		secret string
+		want   string
+	}{
+		{"login quoted", `TAG LOGIN "user" "s3cret"`, "s3cret", `TAG LOGIN "user" "****"`},
+		{"login with quote in password", `TAG LOGIN "user" "pa\"ss"`, `pa"ss`, `TAG LOGIN "user" "****"`},
+		{"authenticate xoauth2", "TAG AUTHENTICATE XOAUTH2 somebase64blob==", "somebase64blob==", "TAG AUTHENTICATE XOAUTH2 ****"},
+		{"authenticate plain", "TAG AUTHENTICATE PLAIN payload", "other", "TAG AUTHENTICATE PLAIN ****"},
+		{"bare secret", "TAG SEARCH FROM mypass@example.com", "mypass", "TAG SEARCH FROM ****@example.com"},
+		{"no secret set", "TAG SELECT INBOX", "", "TAG SELECT INBOX"},
+		{"no match", "TAG NOOP", "sekret", "TAG NOOP"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sanitizeCommand(c.cmd, c.secret); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSearchUIDs(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		if strings.Contains(upper, "UID SEARCH") {
+			w.WriteString("* SEARCH 11 22 33\r\n")
+			w.WriteString(tag + " OK SEARCH completed\r\n")
+			return true
+		}
+		return false
+	}
+	uids, err := d.SearchUIDs(context.Background(), Search().Seen().From("alice@example.com"))
+	if err != nil {
+		t.Fatalf("SearchUIDs: %v", err)
+	}
+	if len(uids) != 3 || uids[0] != 11 || uids[2] != 33 {
+		t.Errorf("want [11,22,33], got %v", uids)
+	}
+}
+
+func TestSetAuthUpdatesCreds(t *testing.T) {
+	d := &Client{}
+	d.SetAuth(PasswordAuth{Username: "alice", Password: "sekret"})
+	if d.Username != "alice" || d.password != "sekret" {
+		t.Errorf("SetAuth didn't mirror creds: %+v", d)
+	}
+	if d.opts.Auth == nil {
+		t.Error("SetAuth should update opts.Auth for Clone")
+	}
+	// Switching to XOAuth2 should replace previous creds.
+	d.SetAuth(XOAuth2{Username: "bob", AccessToken: "tok"})
+	if d.Username != "bob" || d.password != "tok" {
+		t.Errorf("XOAuth2 SetAuth didn't update: %+v", d)
+	}
+}
+
+func TestDialMissingRequirements(t *testing.T) {
+	_, err := Dial(context.Background(), Options{})
+	if err == nil {
+		t.Fatal("expected error when Host/Auth missing")
+	}
+	_, err = Dial(context.Background(), Options{Host: "x"})
+	if err == nil {
+		t.Fatal("expected error when Auth missing")
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -12,6 +12,15 @@
 //   - IMAP IDLE with callbacks for EXISTS/EXPUNGE/FETCH
 //   - Automatic reconnect with re-authentication and folder restore
 //
+// Connections are created with Dial, passing an Options value and an
+// Authenticator (PasswordAuth or XOAuth2):
+//
+//	c, err := imap.Dial(ctx, imap.Options{
+//	    Host: "imap.example.com",
+//	    Port: 993,
+//	    Auth: imap.PasswordAuth{Username: "user", Password: "pass"},
+//	})
+//
 // The API is intentionally small and easy to adopt without pulling in a full
 // IMAP stack. See the README for end-to-end examples and guidance.
 package imap

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,120 @@
+package imap
+
+import (
+	"errors"
+	"strings"
+)
+
+// Sentinel errors. Use errors.Is to check for these conditions; the
+// underlying error may be a *CommandError carrying server response details.
+var (
+	// ErrAuthFailed indicates the server rejected the supplied credentials.
+	// A *CommandError matches only when the reply carries an
+	// [AUTHENTICATIONFAILED] response code (RFC 5530); a bare NO reply to
+	// LOGIN or AUTHENTICATE is left unwrapped because servers also use NO
+	// for transient backend failures, policy denials, app-password
+	// requirements, and disabled mechanisms.
+	ErrAuthFailed = errors.New("imap: authentication failed")
+
+	// ErrFolderNotFound indicates that a SELECT or EXAMINE targeted a
+	// mailbox the server does not have. A *CommandError matches only when
+	// the reply carries a [NONEXISTENT] response code (RFC 5530); a bare
+	// NO reply is left unwrapped because it can also mean ACL denial, a
+	// \Noselect mailbox, or a transient server failure.
+	ErrFolderNotFound = errors.New("imap: folder not found")
+)
+
+// CommandError is the typed error returned when an IMAP command receives a
+// non-OK tagged response (NO, BAD, or BYE). Use errors.As to extract the
+// server reply for inspection, or errors.Is to test for ErrAuthFailed and
+// ErrFolderNotFound.
+type CommandError struct {
+	// Tag is the client-side tag the server echoed in the reply.
+	Tag string
+	// Status is the server status word: "NO", "BAD", or "BYE".
+	Status string
+	// Code is the optional response code from the reply text (e.g.
+	// "AUTHENTICATIONFAILED", "ALERT", "TRYCREATE", "NONEXISTENT").
+	// Empty when the reply did not include a [code] prefix.
+	Code string
+	// Text is the human-readable message from the server, with the
+	// optional [code] prefix stripped.
+	Text string
+	// Command is the verb of the command that triggered the failure
+	// (e.g. "SELECT", "LOGIN", "FETCH"). Empty if not available.
+	Command string
+}
+
+func (e *CommandError) Error() string {
+	var b strings.Builder
+	b.WriteString("imap: ")
+	if e.Command != "" {
+		b.WriteString(e.Command)
+		b.WriteByte(' ')
+	}
+	b.WriteString(e.Status)
+	if e.Code != "" {
+		b.WriteString(" [")
+		b.WriteString(e.Code)
+		b.WriteByte(']')
+	}
+	if e.Text != "" {
+		b.WriteString(": ")
+		b.WriteString(e.Text)
+	}
+	return b.String()
+}
+
+// Is reports whether the CommandError matches a sentinel error.
+func (e *CommandError) Is(target error) bool {
+	switch target {
+	case ErrAuthFailed:
+		return e.Code == "AUTHENTICATIONFAILED"
+	case ErrFolderNotFound:
+		return e.Code == "NONEXISTENT"
+	}
+	return false
+}
+
+// parseCommandError parses a tagged non-OK response line into a CommandError.
+// body is the line content following the tag (i.e. starting with the status
+// word: "NO ...", "BAD ...", or "BYE ..."). tag and command are supplied
+// for context; either may be empty.
+func parseCommandError(tag, command string, body []byte) *CommandError {
+	s := strings.TrimRight(string(body), "\r\n")
+	e := &CommandError{Tag: tag, Command: strings.ToUpper(command)}
+	sp := strings.IndexByte(s, ' ')
+	if sp == -1 {
+		e.Status = strings.ToUpper(s)
+		return e
+	}
+	e.Status = strings.ToUpper(s[:sp])
+	rest := strings.TrimLeft(s[sp+1:], " ")
+	if strings.HasPrefix(rest, "[") {
+		if end := strings.IndexByte(rest, ']'); end != -1 {
+			inside := rest[1:end]
+			if cspace := strings.IndexByte(inside, ' '); cspace != -1 {
+				e.Code = strings.ToUpper(inside[:cspace])
+			} else {
+				e.Code = strings.ToUpper(inside)
+			}
+			rest = strings.TrimLeft(rest[end+1:], " ")
+		}
+	}
+	e.Text = rest
+	return e
+}
+
+// commandVerb extracts the leading verb from a command string (e.g.
+// `SELECT "INBOX"` -> "SELECT"). The optional `UID ` prefix is skipped so
+// that `UID FETCH 1 ALL` reports as `FETCH`. Returns "" if no verb is found.
+func commandVerb(command string) string {
+	command = strings.TrimSpace(command)
+	if len(command) >= 4 && strings.EqualFold(command[:4], "UID ") {
+		command = strings.TrimLeft(command[4:], " \t")
+	}
+	if i := strings.IndexAny(command, " \t"); i != -1 {
+		return strings.ToUpper(command[:i])
+	}
+	return strings.ToUpper(command)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,145 @@
+package imap
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseCommandError(t *testing.T) {
+	tests := []struct {
+		name    string
+		tag     string
+		command string
+		body    string
+		want    CommandError
+	}{
+		{
+			name:    "NO with code and text",
+			tag:     "A001",
+			command: `LOGIN "u" "p"`,
+			body:    "NO [AUTHENTICATIONFAILED] Invalid credentials\r\n",
+			want: CommandError{
+				Tag: "A001", Status: "NO", Code: "AUTHENTICATIONFAILED",
+				Text: "Invalid credentials", Command: "LOGIN",
+			},
+		},
+		{
+			name:    "BAD without code",
+			tag:     "A002",
+			command: `SELECT "INBOX"`,
+			body:    "BAD Command unknown\r\n",
+			want: CommandError{
+				Tag: "A002", Status: "BAD", Text: "Command unknown",
+				Command: "SELECT",
+			},
+		},
+		{
+			name:    "NONEXISTENT code",
+			tag:     "A003",
+			command: `EXAMINE "Missing"`,
+			body:    "NO [NONEXISTENT] Mailbox does not exist\r\n",
+			want: CommandError{
+				Tag: "A003", Status: "NO", Code: "NONEXISTENT",
+				Text: "Mailbox does not exist", Command: "EXAMINE",
+			},
+		},
+		{
+			name:    "code with arguments",
+			tag:     "A004",
+			command: `APPEND "INBOX"`,
+			body:    "NO [BADCHARSET (utf-8 us-ascii)] charset rejected\r\n",
+			want: CommandError{
+				Tag: "A004", Status: "NO", Code: "BADCHARSET",
+				Text: "charset rejected", Command: "APPEND",
+			},
+		},
+		{
+			name:    "BYE bare",
+			tag:     "A005",
+			command: "FETCH 1 BODY[]",
+			body:    "BYE\r\n",
+			want:    CommandError{Tag: "A005", Status: "BYE", Command: "FETCH"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCommandError(tt.tag, commandVerb(tt.command), []byte(tt.body))
+			if *got != tt.want {
+				t.Errorf("parseCommandError = %+v, want %+v", *got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandErrorIs(t *testing.T) {
+	authNo := &CommandError{Status: "NO", Command: "LOGIN", Text: "wrong"}
+	authCodeOnLogin := &CommandError{Status: "NO", Code: "AUTHENTICATIONFAILED", Command: "LOGIN"}
+	folderNo := &CommandError{Status: "NO", Command: "SELECT", Text: "no such mailbox"}
+	folderCode := &CommandError{Status: "NO", Code: "NONEXISTENT", Command: "STATUS"}
+	other := &CommandError{Status: "BAD", Command: "FETCH", Text: "syntax"}
+
+	cases := []struct {
+		name   string
+		err    error
+		target error
+		want   bool
+	}{
+		{"NO LOGIN does not match ErrAuthFailed (could be transient/policy)", authNo, ErrAuthFailed, false},
+		{"AUTHENTICATIONFAILED matches ErrAuthFailed", authCodeOnLogin, ErrAuthFailed, true},
+		{"NO SELECT does not match ErrFolderNotFound (could be ACL/Noselect)", folderNo, ErrFolderNotFound, false},
+		{"NONEXISTENT matches ErrFolderNotFound", folderCode, ErrFolderNotFound, true},
+		{"BAD FETCH does not match ErrAuthFailed", other, ErrAuthFailed, false},
+		{"BAD FETCH does not match ErrFolderNotFound", other, ErrFolderNotFound, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := errors.Is(tc.err, tc.target); got != tc.want {
+				t.Errorf("errors.Is = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommandErrorAs(t *testing.T) {
+	var ce *CommandError
+	src := &CommandError{Tag: "A1", Status: "NO", Code: "FOO", Text: "bar"}
+	if !errors.As(error(src), &ce) {
+		t.Fatal("errors.As failed")
+	}
+	if ce.Tag != "A1" || ce.Code != "FOO" {
+		t.Errorf("As yielded wrong value: %+v", ce)
+	}
+}
+
+func TestCommandErrorString(t *testing.T) {
+	cases := []struct {
+		err  CommandError
+		want string
+	}{
+		{CommandError{Status: "NO", Command: "LOGIN", Text: "bad creds"}, "imap: LOGIN NO: bad creds"},
+		{CommandError{Status: "NO", Code: "NONEXISTENT", Command: "SELECT", Text: "no mb"}, "imap: SELECT NO [NONEXISTENT]: no mb"},
+		{CommandError{Status: "BYE"}, "imap: BYE"},
+	}
+	for _, c := range cases {
+		if got := c.err.Error(); got != c.want {
+			t.Errorf("Error()=%q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestCommandVerb(t *testing.T) {
+	cases := map[string]string{
+		`SELECT "INBOX"`:    "SELECT",
+		"FETCH 1:5 ALL":     "FETCH",
+		"UID FETCH 1 ALL":   "FETCH",
+		"uid search ALL":    "SEARCH",
+		"UID  STORE 1 +FLAGS": "STORE",
+		"":                  "",
+		"NOOP":              "NOOP",
+	}
+	for in, want := range cases {
+		if got := commandVerb(in); got != want {
+			t.Errorf("commandVerb(%q)=%q, want %q", in, got, want)
+		}
+	}
+}

--- a/examples/basic_connection/main.go
+++ b/examples/basic_connection/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -8,18 +9,24 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
+var ctx = context.Background()
+
 func main() {
-	imap.Verbose = false                   // Set to true to see all IMAP commands/responses
-	imap.RetryCount = 3                    // Number of retries for failed commands
-	imap.DialTimeout = 10 * time.Second    // Connection timeout
-	imap.CommandTimeout = 30 * time.Second // Command timeout
+	imap.Verbose = false // Set to true to see all IMAP commands/responses
 
 	// For self-signed certificates (use with caution!)
 	// imap.TLSSkipVerify = true
 
-	// Connect with standard LOGIN authentication
-	// Replace with your actual credentials and server
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+	// Connect with standard LOGIN authentication.
+	// Replace with your actual credentials and server.
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host:           "mail.server.com",
+		Port:           993,
+		Auth:           imap.PasswordAuth{Username: "username", Password: "password"},
+		DialTimeout:    10 * time.Second,
+		CommandTimeout: 30 * time.Second,
+		RetryCount:     3,
+	})
 	if err != nil {
 		log.Fatalf("Failed to connect: %v", err)
 	}
@@ -30,7 +37,7 @@ func main() {
 	}()
 
 	// Quick test - list folders
-	folders, err := m.GetFolders()
+	folders, err := m.GetFolders(ctx)
 	if err != nil {
 		log.Fatalf("Failed to get folders: %v", err)
 	}

--- a/examples/complete_example/main.go
+++ b/examples/complete_example/main.go
@@ -42,7 +42,7 @@ func listAvailableFolders(m *imap.Client) error {
 	return nil
 }
 
-func fetchUnreadEmails(m *imap.Client) ([]int, error) {
+func fetchUnreadEmails(m *imap.Client) ([]imap.UID, error) {
 	fmt.Println("\nSelecting INBOX...")
 	if err := m.SelectFolder(ctx, "INBOX"); err != nil {
 		return nil, fmt.Errorf("failed to select INBOX: %w", err)
@@ -57,7 +57,7 @@ func fetchUnreadEmails(m *imap.Client) ([]int, error) {
 	return unreadUIDs, nil
 }
 
-func displayEmails(m *imap.Client, unreadUIDs []int) {
+func displayEmails(m *imap.Client, unreadUIDs []imap.UID) {
 	limit := 5
 	if len(unreadUIDs) < limit {
 		limit = len(unreadUIDs)
@@ -82,7 +82,7 @@ func displayEmails(m *imap.Client, unreadUIDs []int) {
 	}
 }
 
-func printEmailDetails(uid int, email *imap.Email) {
+func printEmailDetails(uid imap.UID, email *imap.Email) {
 	fmt.Printf("\n--- Email UID %d ---\n", uid)
 	fmt.Printf("From: %s\n", email.From)
 	fmt.Printf("Subject: %s\n", email.Subject)
@@ -103,7 +103,7 @@ func printEmailDetails(uid int, email *imap.Email) {
 	}
 }
 
-func markFirstAsRead(m *imap.Client, uid int) {
+func markFirstAsRead(m *imap.Client, uid imap.UID) {
 	fmt.Printf("\nMarking email %d as read...\n", uid)
 	if err := m.MarkSeen(ctx, uid); err != nil {
 		fmt.Printf("Failed to mark as read: %v\n", err)
@@ -126,7 +126,7 @@ func monitorBriefly(m *imap.Client) {
 	fmt.Println("\nMonitoring for new emails (10 seconds)...")
 	handler := &imap.IdleHandler{
 		OnExists: func(e imap.ExistsEvent) {
-			fmt.Printf("  New email arrived! (message #%d)\n", e.MessageIndex)
+			fmt.Printf("  New email arrived! (message #%d)\n", e.SeqNum)
 		},
 	}
 

--- a/examples/complete_example/main.go
+++ b/examples/complete_example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -8,24 +9,30 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
-func initializeClient() (*imap.Dialer, error) {
+var ctx = context.Background()
+
+func initializeClient() (*imap.Client, error) {
 	imap.Verbose = false
-	imap.RetryCount = 3
-	imap.DialTimeout = 10 * time.Second
-	imap.CommandTimeout = 30 * time.Second
 
 	fmt.Println("Connecting to IMAP server...")
 	// NOTE: Replace with your actual credentials and server
-	m, err := imap.New("your-email@gmail.com", "your-password", "imap.gmail.com", 993)
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host:           "imap.gmail.com",
+		Port:           993,
+		Auth:           imap.PasswordAuth{Username: "your-email@gmail.com", Password: "your-password"},
+		DialTimeout:    10 * time.Second,
+		CommandTimeout: 30 * time.Second,
+		RetryCount:     3,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("connection failed: %w", err)
 	}
 	return m, nil
 }
 
-func listAvailableFolders(m *imap.Dialer) error {
+func listAvailableFolders(m *imap.Client) error {
 	fmt.Println("\nAvailable folders:")
-	folders, err := m.GetFolders()
+	folders, err := m.GetFolders(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get folders: %w", err)
 	}
@@ -35,14 +42,14 @@ func listAvailableFolders(m *imap.Dialer) error {
 	return nil
 }
 
-func fetchUnreadEmails(m *imap.Dialer) ([]int, error) {
+func fetchUnreadEmails(m *imap.Client) ([]int, error) {
 	fmt.Println("\nSelecting INBOX...")
-	if err := m.SelectFolder("INBOX"); err != nil {
+	if err := m.SelectFolder(ctx, "INBOX"); err != nil {
 		return nil, fmt.Errorf("failed to select INBOX: %w", err)
 	}
 
 	fmt.Println("\nSearching for unread emails...")
-	unreadUIDs, err := m.GetUIDs("UNSEEN")
+	unreadUIDs, err := m.GetUIDs(ctx, "UNSEEN")
 	if err != nil {
 		return nil, fmt.Errorf("search failed: %w", err)
 	}
@@ -50,7 +57,7 @@ func fetchUnreadEmails(m *imap.Dialer) ([]int, error) {
 	return unreadUIDs, nil
 }
 
-func displayEmails(m *imap.Dialer, unreadUIDs []int) {
+func displayEmails(m *imap.Client, unreadUIDs []int) {
 	limit := 5
 	if len(unreadUIDs) < limit {
 		limit = len(unreadUIDs)
@@ -61,7 +68,7 @@ func displayEmails(m *imap.Dialer, unreadUIDs []int) {
 	}
 
 	fmt.Printf("\nFetching first %d unread emails...\n", limit)
-	emails, err := m.GetEmails(unreadUIDs[:limit]...)
+	emails, err := m.GetEmails(ctx, unreadUIDs[:limit]...)
 	if err != nil {
 		log.Fatalf("Failed to fetch emails: %v", err)
 	}
@@ -96,18 +103,18 @@ func printEmailDetails(uid int, email *imap.Email) {
 	}
 }
 
-func markFirstAsRead(m *imap.Dialer, uid int) {
+func markFirstAsRead(m *imap.Client, uid int) {
 	fmt.Printf("\nMarking email %d as read...\n", uid)
-	if err := m.MarkSeen(uid); err != nil {
+	if err := m.MarkSeen(ctx, uid); err != nil {
 		fmt.Printf("Failed to mark as read: %v\n", err)
 	}
 }
 
-func printMailboxStats(m *imap.Dialer) {
+func printMailboxStats(m *imap.Client) {
 	fmt.Println("\nMailbox Statistics:")
-	allUIDs, _ := m.GetUIDs("ALL")
-	seenUIDs, _ := m.GetUIDs("SEEN")
-	flaggedUIDs, _ := m.GetUIDs("FLAGGED")
+	allUIDs, _ := m.GetUIDs(ctx, "ALL")
+	seenUIDs, _ := m.GetUIDs(ctx, "SEEN")
+	flaggedUIDs, _ := m.GetUIDs(ctx, "FLAGGED")
 
 	fmt.Printf("  Total emails: %d\n", len(allUIDs))
 	fmt.Printf("  Read emails: %d\n", len(seenUIDs))
@@ -115,7 +122,7 @@ func printMailboxStats(m *imap.Dialer) {
 	fmt.Printf("  Flagged emails: %d\n", len(flaggedUIDs))
 }
 
-func monitorBriefly(m *imap.Dialer) {
+func monitorBriefly(m *imap.Client) {
 	fmt.Println("\nMonitoring for new emails (10 seconds)...")
 	handler := &imap.IdleHandler{
 		OnExists: func(e imap.ExistsEvent) {
@@ -123,7 +130,7 @@ func monitorBriefly(m *imap.Dialer) {
 		},
 	}
 
-	if err := m.StartIdle(handler); err == nil {
+	if err := m.StartIdle(ctx, handler); err == nil {
 		time.Sleep(10 * time.Second)
 		_ = m.StopIdle()
 	}

--- a/examples/email_operations/main.go
+++ b/examples/email_operations/main.go
@@ -23,7 +23,7 @@ func connectAndLogin() (*imap.Client, error) {
 	return m, nil
 }
 
-func getFirstUIDs(m *imap.Client) ([]int, error) {
+func getFirstUIDs(m *imap.Client) ([]imap.UID, error) {
 	err := m.SelectFolder(ctx, "INBOX")
 	if err != nil {
 		return nil, fmt.Errorf("failed to select INBOX: %w", err)
@@ -52,7 +52,7 @@ func findArchiveFolder(m *imap.Client) bool {
 	return false
 }
 
-func demonstrateMoveEmail(m *imap.Client, uid int, archiveExists bool) {
+func demonstrateMoveEmail(m *imap.Client, uid imap.UID, archiveExists bool) {
 	fmt.Println("=== Moving Emails ===")
 
 	if !archiveExists {
@@ -78,7 +78,7 @@ func demonstrateMoveEmail(m *imap.Client, uid int, archiveExists bool) {
 	fmt.Printf("Moved email back to INBOX for demo\n")
 }
 
-func demonstrateCopyEmail(m *imap.Client, uid int, archiveExists bool) {
+func demonstrateCopyEmail(m *imap.Client, uid imap.UID, archiveExists bool) {
 	fmt.Println("\n=== Copying Emails ===")
 
 	if !archiveExists {
@@ -107,7 +107,7 @@ func demonstrateAppend(m *imap.Client) {
 	}
 }
 
-func demonstrateIndividualFlags(m *imap.Client, uid int) {
+func demonstrateIndividualFlags(m *imap.Client, uid imap.UID) {
 	fmt.Println("\n=== Setting Individual Flags ===")
 
 	err := m.MarkSeen(ctx, uid)
@@ -128,7 +128,7 @@ func demonstrateIndividualFlags(m *imap.Client, uid int) {
 	}
 }
 
-func demonstrateMultipleFlags(m *imap.Client, uid int) {
+func demonstrateMultipleFlags(m *imap.Client, uid imap.UID) {
 	fmt.Println("\n=== Setting Multiple Flags ===")
 
 	flags := imap.Flags{
@@ -153,7 +153,7 @@ func demonstrateMultipleFlags(m *imap.Client, uid int) {
 	}
 }
 
-func demonstrateCustomKeywords(m *imap.Client, uid int) {
+func demonstrateCustomKeywords(m *imap.Client, uid imap.UID) {
 	fmt.Println("\n=== Custom Keywords ===")
 
 	flags := imap.Flags{
@@ -175,7 +175,7 @@ func demonstrateCustomKeywords(m *imap.Client, uid int) {
 	}
 }
 
-func demonstrateBatchFlags(m *imap.Client, uids []int) {
+func demonstrateBatchFlags(m *imap.Client, uids []imap.UID) {
 	fmt.Println("\n=== Batch Flag Operations ===")
 
 	if len(uids) <= 1 {

--- a/examples/email_operations/main.go
+++ b/examples/email_operations/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -8,21 +9,27 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
-func connectAndLogin() (*imap.Dialer, error) {
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+var ctx = context.Background()
+
+func connectAndLogin() (*imap.Client, error) {
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host: "mail.server.com",
+		Port: 993,
+		Auth: imap.PasswordAuth{Username: "username", Password: "password"},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
 	return m, nil
 }
 
-func getFirstUIDs(m *imap.Dialer) ([]int, error) {
-	err := m.SelectFolder("INBOX")
+func getFirstUIDs(m *imap.Client) ([]int, error) {
+	err := m.SelectFolder(ctx, "INBOX")
 	if err != nil {
 		return nil, fmt.Errorf("failed to select INBOX: %w", err)
 	}
 
-	uids, err := m.GetUIDs("1:3") // Get first 3 emails
+	uids, err := m.GetUIDs(ctx, "1:3") // Get first 3 emails
 	if err != nil {
 		return nil, fmt.Errorf("failed to get UIDs: %w", err)
 	}
@@ -30,8 +37,8 @@ func getFirstUIDs(m *imap.Dialer) ([]int, error) {
 	return uids, nil
 }
 
-func findArchiveFolder(m *imap.Dialer) bool {
-	folders, err := m.GetFolders()
+func findArchiveFolder(m *imap.Client) bool {
+	folders, err := m.GetFolders(ctx)
 	if err != nil {
 		log.Printf("Failed to get folders: %v", err)
 		return false
@@ -45,7 +52,7 @@ func findArchiveFolder(m *imap.Dialer) bool {
 	return false
 }
 
-func demonstrateMoveEmail(m *imap.Dialer, uid int, archiveExists bool) {
+func demonstrateMoveEmail(m *imap.Client, uid int, archiveExists bool) {
 	fmt.Println("=== Moving Emails ===")
 
 	if !archiveExists {
@@ -53,7 +60,7 @@ func demonstrateMoveEmail(m *imap.Dialer, uid int, archiveExists bool) {
 		return
 	}
 
-	err := m.MoveEmail(uid, "INBOX/Archive")
+	err := m.MoveEmail(ctx, uid, "INBOX/Archive")
 	if err != nil {
 		log.Printf("Failed to move email: %v", err)
 		return
@@ -61,17 +68,17 @@ func demonstrateMoveEmail(m *imap.Dialer, uid int, archiveExists bool) {
 	fmt.Printf("Moved email UID %d to Archive\n", uid)
 
 	// Move it back for further demos
-	if err := m.SelectFolder("INBOX/Archive"); err != nil {
+	if err := m.SelectFolder(ctx, "INBOX/Archive"); err != nil {
 		log.Printf("Failed to select Archive folder: %v", err)
-	} else if err := m.MoveEmail(uid, "INBOX"); err != nil {
+	} else if err := m.MoveEmail(ctx, uid, "INBOX"); err != nil {
 		log.Printf("Failed to move email back: %v", err)
-	} else if err := m.SelectFolder("INBOX"); err != nil {
+	} else if err := m.SelectFolder(ctx, "INBOX"); err != nil {
 		log.Printf("Failed to select INBOX: %v", err)
 	}
 	fmt.Printf("Moved email back to INBOX for demo\n")
 }
 
-func demonstrateCopyEmail(m *imap.Dialer, uid int, archiveExists bool) {
+func demonstrateCopyEmail(m *imap.Client, uid int, archiveExists bool) {
 	fmt.Println("\n=== Copying Emails ===")
 
 	if !archiveExists {
@@ -79,7 +86,7 @@ func demonstrateCopyEmail(m *imap.Dialer, uid int, archiveExists bool) {
 		return
 	}
 
-	err := m.CopyEmail(uid, "INBOX/Archive")
+	err := m.CopyEmail(ctx, uid, "INBOX/Archive")
 	if err != nil {
 		log.Printf("Failed to copy email: %v", err)
 	} else {
@@ -87,11 +94,11 @@ func demonstrateCopyEmail(m *imap.Dialer, uid int, archiveExists bool) {
 	}
 }
 
-func demonstrateAppend(m *imap.Dialer) {
+func demonstrateAppend(m *imap.Client) {
 	fmt.Println("\n=== Appending Messages (Upload) ===")
 
 	msg := []byte("From: me@example.com\r\nTo: you@example.com\r\nSubject: Test Draft\r\n\r\nThis is a test message uploaded via APPEND.")
-	err := m.Append("Drafts", []string{`\Draft`, `\Seen`}, time.Now(), msg)
+	err := m.Append(ctx, "Drafts", []string{`\Draft`, `\Seen`}, time.Now(), msg)
 	if err != nil {
 		log.Printf("Failed to append message: %v", err)
 		fmt.Println("(Note: Append requires a valid target folder)")
@@ -100,10 +107,10 @@ func demonstrateAppend(m *imap.Dialer) {
 	}
 }
 
-func demonstrateIndividualFlags(m *imap.Dialer, uid int) {
+func demonstrateIndividualFlags(m *imap.Client, uid int) {
 	fmt.Println("\n=== Setting Individual Flags ===")
 
-	err := m.MarkSeen(uid)
+	err := m.MarkSeen(ctx, uid)
 	if err != nil {
 		log.Printf("Failed to mark as seen: %v", err)
 	} else {
@@ -113,7 +120,7 @@ func demonstrateIndividualFlags(m *imap.Dialer, uid int) {
 	flags := imap.Flags{
 		Seen: imap.FlagRemove,
 	}
-	err = m.SetFlags(uid, flags)
+	err = m.SetFlags(ctx, uid, flags)
 	if err != nil {
 		log.Printf("Failed to mark as unread: %v", err)
 	} else {
@@ -121,7 +128,7 @@ func demonstrateIndividualFlags(m *imap.Dialer, uid int) {
 	}
 }
 
-func demonstrateMultipleFlags(m *imap.Dialer, uid int) {
+func demonstrateMultipleFlags(m *imap.Client, uid int) {
 	fmt.Println("\n=== Setting Multiple Flags ===")
 
 	flags := imap.Flags{
@@ -129,7 +136,7 @@ func demonstrateMultipleFlags(m *imap.Dialer, uid int) {
 		Flagged:  imap.FlagAdd,    // Star/flag the email
 		Answered: imap.FlagRemove, // Remove answered flag
 	}
-	err := m.SetFlags(uid, flags)
+	err := m.SetFlags(ctx, uid, flags)
 	if err != nil {
 		log.Printf("Failed to set flags: %v", err)
 	} else {
@@ -140,13 +147,13 @@ func demonstrateMultipleFlags(m *imap.Dialer, uid int) {
 	}
 
 	// Check the flags
-	overviews, err := m.GetOverviews(uid)
+	overviews, err := m.GetOverviews(ctx, uid)
 	if err == nil && len(overviews) > 0 {
 		fmt.Printf("Current flags on UID %d: %v\n", uid, overviews[uid].Flags)
 	}
 }
 
-func demonstrateCustomKeywords(m *imap.Dialer, uid int) {
+func demonstrateCustomKeywords(m *imap.Client, uid int) {
 	fmt.Println("\n=== Custom Keywords ===")
 
 	flags := imap.Flags{
@@ -157,7 +164,7 @@ func demonstrateCustomKeywords(m *imap.Dialer, uid int) {
 			"$FollowUp":  true,  // Add this
 		},
 	}
-	err := m.SetFlags(uid, flags)
+	err := m.SetFlags(ctx, uid, flags)
 	if err != nil {
 		log.Printf("Failed to set custom keywords: %v", err)
 		fmt.Println("(Note: Not all servers support custom keywords)")
@@ -168,7 +175,7 @@ func demonstrateCustomKeywords(m *imap.Dialer, uid int) {
 	}
 }
 
-func demonstrateBatchFlags(m *imap.Dialer, uids []int) {
+func demonstrateBatchFlags(m *imap.Client, uids []int) {
 	fmt.Println("\n=== Batch Flag Operations ===")
 
 	if len(uids) <= 1 {
@@ -177,7 +184,7 @@ func demonstrateBatchFlags(m *imap.Dialer, uids []int) {
 
 	// Mark multiple emails as read
 	for _, batchUID := range uids[:2] {
-		err := m.MarkSeen(batchUID)
+		err := m.MarkSeen(ctx, batchUID)
 		if err != nil {
 			log.Printf("Failed to mark UID %d as seen: %v", batchUID, err)
 		} else {
@@ -190,7 +197,7 @@ func demonstrateBatchFlags(m *imap.Dialer, uids []int) {
 		flags := imap.Flags{
 			Flagged: imap.FlagAdd,
 		}
-		err := m.SetFlags(batchUID, flags)
+		err := m.SetFlags(ctx, batchUID, flags)
 		if err != nil {
 			log.Printf("Failed to flag UID %d: %v", batchUID, err)
 		} else {
@@ -204,14 +211,14 @@ func printFlagReference() {
 
 	/*
 		// Get an email to delete (maybe from Trash or a test folder)
-		err = m.SelectFolder("Trash")
+		err = m.SelectFolder(ctx, "Trash")
 		if err == nil {
-			trashUIDs, _ := m.GetUIDs("1")
+			trashUIDs, _ := m.GetUIDs(ctx, "1")
 			if len(trashUIDs) > 0 {
 				deleteUID := trashUIDs[0]
 
 				// Step 1: Mark as deleted (sets \Deleted flag)
-				err = m.DeleteEmail(deleteUID)
+				err = m.DeleteEmail(ctx, deleteUID)
 				if err != nil {
 					log.Printf("Failed to mark for deletion: %v", err)
 				} else {
@@ -219,7 +226,7 @@ func printFlagReference() {
 				}
 
 				// Step 2: Expunge to permanently remove all \Deleted emails
-				err = m.Expunge()
+				err = m.Expunge(ctx)
 				if err != nil {
 					log.Printf("Failed to expunge: %v", err)
 				} else {
@@ -230,7 +237,7 @@ func printFlagReference() {
 			}
 
 			// Go back to INBOX
-			m.SelectFolder("INBOX")
+			m.SelectFolder(ctx, "INBOX")
 		} else {
 			fmt.Println("Trash folder not found, skipping deletion demo")
 		}

--- a/examples/error_handling/main.go
+++ b/examples/error_handling/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -8,11 +9,10 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
+var ctx = context.Background()
+
 func main() {
 	fmt.Println("=== Error Handling and Reconnection Example ===")
-
-	// Configure retry and timeout behavior
-	configureLibrarySettings()
 
 	// Example 1: Handle connection errors
 	handleConnectionErrors()
@@ -27,33 +27,26 @@ func main() {
 	timeoutConfiguration()
 }
 
-func configureLibrarySettings() {
-	fmt.Println("1. Configuring Library Settings")
-	fmt.Println("--------------------------------")
-
-	// Set retry configuration
-	imap.RetryCount = 5 // Will retry failed operations 5 times
-	fmt.Printf("RetryCount set to: %d\n", imap.RetryCount)
-
-	// Enable verbose mode to see what's happening
-	imap.Verbose = false // Set to true to see all IMAP commands/responses
-	fmt.Printf("Verbose mode: %v\n", imap.Verbose)
-
-	// Configure timeouts
-	imap.DialTimeout = 10 * time.Second    // Connection timeout
-	imap.CommandTimeout = 30 * time.Second // Individual command timeout
-	fmt.Printf("DialTimeout: %v\n", imap.DialTimeout)
-	fmt.Printf("CommandTimeout: %v\n", imap.CommandTimeout)
-
-	fmt.Println()
+// baseOptions returns the options used across examples. Replace host, port,
+// and credentials with your own.
+func baseOptions(username, password, host string) imap.Options {
+	return imap.Options{
+		Host:           host,
+		Port:           993,
+		Auth:           imap.PasswordAuth{Username: username, Password: password},
+		DialTimeout:    10 * time.Second,
+		CommandTimeout: 30 * time.Second,
+		RetryCount:     5,
+	}
 }
 
 func handleConnectionErrors() {
-	fmt.Println("2. Handling Connection Errors")
+	fmt.Println("1. Handling Connection Errors")
 	fmt.Println("------------------------------")
+	ctx := context.Background()
 
 	// Try to connect with invalid credentials (will fail)
-	m, err := imap.New("invalid-user", "invalid-pass", "imap.gmail.com", 993)
+	m, err := imap.Dial(ctx, baseOptions("invalid-user", "invalid-pass", "imap.gmail.com"))
 	if err != nil {
 		fmt.Printf("Expected error occurred: %v\n", err)
 		fmt.Println("This is how you handle initial connection failures")
@@ -67,7 +60,7 @@ func handleConnectionErrors() {
 	}
 
 	// Try to connect to non-existent server
-	m, err = imap.New("user", "pass", "non-existent-server.invalid", 993)
+	m, err = imap.Dial(ctx, baseOptions("user", "pass", "non-existent-server.invalid"))
 	if err != nil {
 		fmt.Printf("Expected error for invalid server: %v\n", err)
 	} else {
@@ -82,11 +75,12 @@ func handleConnectionErrors() {
 }
 
 func robustEmailFetch() {
-	fmt.Println("3. Robust Email Fetching")
+	fmt.Println("2. Robust Email Fetching")
 	fmt.Println("-------------------------")
 
+	ctx := context.Background()
 	// NOTE: Replace with your actual credentials and server
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+	m, err := imap.Dial(ctx, baseOptions("username", "password", "mail.server.com"))
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		fmt.Println("Skipping robust fetch example (need valid credentials)")
@@ -111,16 +105,15 @@ func robustEmailFetch() {
 	fmt.Println()
 
 	// Select folder with automatic retry
-	err = m.SelectFolder("INBOX")
+	err = m.SelectFolder(ctx, "INBOX")
 	if err != nil {
-		// This only fails after all retries are exhausted
-		fmt.Printf("Failed to select folder after %d retries: %v\n", imap.RetryCount, err)
+		fmt.Printf("Failed to select folder: %v\n", err)
 		return
 	}
 	fmt.Println("Selected INBOX successfully")
 
 	// Fetch emails with automatic retry on network issues
-	uids, err := m.GetUIDs("1:5")
+	uids, err := m.GetUIDs(ctx, "1:5")
 	if err != nil {
 		fmt.Printf("Search failed after retries: %v\n", err)
 		return
@@ -128,8 +121,7 @@ func robustEmailFetch() {
 	fmt.Printf("Found %d UIDs with automatic retry support\n", len(uids))
 
 	if len(uids) > 0 {
-		// Fetch emails - will automatically retry on failure
-		emails, err := m.GetEmails(uids[0])
+		emails, err := m.GetEmails(ctx, uids[0])
 		if err != nil {
 			fmt.Printf("Fetch failed after retries: %v\n", err)
 		} else {
@@ -146,11 +138,11 @@ func robustEmailFetch() {
 }
 
 func manualReconnection() {
-	fmt.Println("4. Manual Reconnection")
+	fmt.Println("3. Manual Reconnection")
 	fmt.Println("-----------------------")
 
-	// NOTE: Replace with your actual credentials and server
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+	ctx := context.Background()
+	m, err := imap.Dial(ctx, baseOptions("username", "password", "mail.server.com"))
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		fmt.Println("Skipping manual reconnection example (need valid credentials)")
@@ -165,21 +157,16 @@ func manualReconnection() {
 
 	fmt.Println("Connected successfully!")
 
-	// Select a folder
-	err = m.SelectFolder("INBOX")
+	err = m.SelectFolder(ctx, "INBOX")
 	if err != nil {
 		fmt.Printf("Failed to select folder: %v\n", err)
-
-		// You can manually trigger a reconnection
 		fmt.Println("Attempting manual reconnection...")
-		if err := m.Reconnect(); err != nil {
+		if err := m.Reconnect(ctx); err != nil {
 			fmt.Printf("Manual reconnection failed: %v\n", err)
 			return
 		}
 		fmt.Println("Reconnected successfully!")
-
-		// Try selecting folder again
-		if err := m.SelectFolder("INBOX"); err != nil {
+		if err := m.SelectFolder(ctx, "INBOX"); err != nil {
 			fmt.Printf("Failed to select folder after reconnect: %v\n", err)
 			return
 		}
@@ -190,23 +177,22 @@ func manualReconnection() {
 }
 
 func timeoutConfiguration() {
-	fmt.Println("5. Timeout Configuration")
+	fmt.Println("4. Timeout Configuration")
 	fmt.Println("-------------------------")
 
-	// Configure aggressive timeouts for demonstration
-	originalDialTimeout := imap.DialTimeout
-	originalCommandTimeout := imap.CommandTimeout
+	// Use aggressive per-call timeouts for demonstration.
+	opts := imap.Options{
+		Host:           "slow-server.example.com",
+		Port:           993,
+		Auth:           imap.PasswordAuth{Username: "user", Password: "pass"},
+		DialTimeout:    2 * time.Second, // Very short connection timeout
+		CommandTimeout: 5 * time.Second, // Short command timeout
+	}
+	fmt.Printf("Using aggressive timeouts: DialTimeout=%v, CommandTimeout=%v\n",
+		opts.DialTimeout, opts.CommandTimeout)
 
-	imap.DialTimeout = 2 * time.Second    // Very short connection timeout
-	imap.CommandTimeout = 5 * time.Second // Short command timeout
-
-	fmt.Printf("Using aggressive timeouts:\n")
-	fmt.Printf("  DialTimeout: %v\n", imap.DialTimeout)
-	fmt.Printf("  CommandTimeout: %v\n", imap.CommandTimeout)
-
-	// Try to connect with short timeout
 	start := time.Now()
-	m, err := imap.New("user", "pass", "slow-server.example.com", 993)
+	m, err := imap.Dial(context.Background(), opts)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -219,10 +205,9 @@ func timeoutConfiguration() {
 			}
 		}()
 
-		// This search will timeout after CommandTimeout
 		fmt.Println("Attempting a command that might timeout...")
 		start = time.Now()
-		_, err := m.GetUIDs("ALL")
+		_, err := m.GetUIDs(ctx, "ALL")
 		elapsed = time.Since(start)
 
 		if err != nil {
@@ -232,17 +217,12 @@ func timeoutConfiguration() {
 		}
 	}
 
-	// Restore original timeouts
-	imap.DialTimeout = originalDialTimeout
-	imap.CommandTimeout = originalCommandTimeout
-
 	fmt.Println()
 	fmt.Println("=== Best Practices for Error Handling ===")
-	fmt.Println("1. Set appropriate RetryCount based on your needs")
-	fmt.Println("2. Use reasonable timeouts (10-30 seconds typically)")
+	fmt.Println("1. Set a reasonable RetryCount for transient failures")
+	fmt.Println("2. Use sensible timeouts (10-30 seconds typically)")
 	fmt.Println("3. Always check errors from operations")
 	fmt.Println("4. Consider manual reconnection for critical operations")
-	fmt.Println("5. Enable Verbose mode when debugging issues")
+	fmt.Println("5. Enable imap.Verbose when debugging issues")
 	fmt.Println("6. Log errors for monitoring and debugging")
-	fmt.Println("7. Implement exponential backoff for custom retry logic")
 }

--- a/examples/fetch_emails/main.go
+++ b/examples/fetch_emails/main.go
@@ -30,7 +30,7 @@ func connectAndSelectInbox() (*imap.Client, error) {
 	return m, nil
 }
 
-func fetchOverviews(m *imap.Client, uids []int) error {
+func fetchOverviews(m *imap.Client, uids []imap.UID) error {
 	fmt.Println("=== Fetching Overviews (Headers Only - FAST) ===")
 
 	overviews, err := m.GetOverviews(ctx, uids...)
@@ -92,7 +92,7 @@ func printAttachments(email *imap.Email) {
 	}
 }
 
-func fetchFullEmails(m *imap.Client, uids []int) (map[int]*imap.Email, error) {
+func fetchFullEmails(m *imap.Client, uids []imap.UID) (map[imap.UID]*imap.Email, error) {
 	fmt.Println("=== Fetching Full Emails (With Bodies - SLOWER) ===")
 
 	// Limit to first 3 for full fetch (to keep example fast)
@@ -129,7 +129,7 @@ func fetchFullEmails(m *imap.Client, uids []int) (map[int]*imap.Email, error) {
 	return emails, nil
 }
 
-func printEmailSummaries(emails map[int]*imap.Email) {
+func printEmailSummaries(emails map[imap.UID]*imap.Email) {
 	fmt.Println("\n=== Using the String() Method ===")
 
 	for uid, email := range emails {
@@ -139,7 +139,7 @@ func printEmailSummaries(emails map[int]*imap.Email) {
 	}
 }
 
-func processAttachments(emails map[int]*imap.Email) {
+func processAttachments(emails map[imap.UID]*imap.Email) {
 	fmt.Println("\n=== Processing Attachments Example ===")
 
 	for uid, email := range emails {

--- a/examples/fetch_emails/main.go
+++ b/examples/fetch_emails/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -8,13 +9,19 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
-func connectAndSelectInbox() (*imap.Dialer, error) {
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+var ctx = context.Background()
+
+func connectAndSelectInbox() (*imap.Client, error) {
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host: "mail.server.com",
+		Port: 993,
+		Auth: imap.PasswordAuth{Username: "username", Password: "password"},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
 
-	err = m.SelectFolder("INBOX")
+	err = m.SelectFolder(ctx, "INBOX")
 	if err != nil {
 		_ = m.Close()
 		return nil, fmt.Errorf("failed to select INBOX: %w", err)
@@ -23,10 +30,10 @@ func connectAndSelectInbox() (*imap.Dialer, error) {
 	return m, nil
 }
 
-func fetchOverviews(m *imap.Dialer, uids []int) error {
+func fetchOverviews(m *imap.Client, uids []int) error {
 	fmt.Println("=== Fetching Overviews (Headers Only - FAST) ===")
 
-	overviews, err := m.GetOverviews(uids...)
+	overviews, err := m.GetOverviews(ctx, uids...)
 	if err != nil {
 		return fmt.Errorf("failed to get overviews: %w", err)
 	}
@@ -85,7 +92,7 @@ func printAttachments(email *imap.Email) {
 	}
 }
 
-func fetchFullEmails(m *imap.Dialer, uids []int) (map[int]*imap.Email, error) {
+func fetchFullEmails(m *imap.Client, uids []int) (map[int]*imap.Email, error) {
 	fmt.Println("=== Fetching Full Emails (With Bodies - SLOWER) ===")
 
 	// Limit to first 3 for full fetch (to keep example fast)
@@ -94,7 +101,7 @@ func fetchFullEmails(m *imap.Dialer, uids []int) (map[int]*imap.Email, error) {
 		fetchUIDs = uids[:3]
 	}
 
-	emails, err := m.GetEmails(fetchUIDs...)
+	emails, err := m.GetEmails(ctx, fetchUIDs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get emails: %w", err)
 	}
@@ -168,7 +175,7 @@ func main() {
 		}
 	}()
 
-	uids, err := m.GetUIDs("1:5") // Get first 5 emails
+	uids, err := m.GetUIDs(ctx, "1:5") // Get first 5 emails
 	if err != nil {
 		log.Fatalf("Failed to get UIDs: %v", err)
 	}

--- a/examples/folders/main.go
+++ b/examples/folders/main.go
@@ -1,22 +1,29 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	imap "github.com/BrianLeishman/go-imap"
 )
 
-func connectToServer() (*imap.Dialer, error) {
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+var ctx = context.Background()
+
+func connectToServer() (*imap.Client, error) {
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host: "mail.server.com",
+		Port: 993,
+		Auth: imap.PasswordAuth{Username: "username", Password: "password"},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
 	return m, nil
 }
 
-func listFolders(m *imap.Dialer) error {
-	folders, err := m.GetFolders()
+func listFolders(m *imap.Client) error {
+	folders, err := m.GetFolders(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get folders: %w", err)
 	}
@@ -28,31 +35,31 @@ func listFolders(m *imap.Dialer) error {
 	return nil
 }
 
-func demonstrateFolderSelection(m *imap.Dialer) error {
+func demonstrateFolderSelection(m *imap.Client) error {
 	fmt.Println("\n--- Folder Operations ---")
 
 	// Select a folder for operations (read-write mode)
-	err := m.SelectFolder("INBOX")
+	err := m.SelectFolder(ctx, "INBOX")
 	if err != nil {
 		return fmt.Errorf("failed to select INBOX: %w", err)
 	}
 	fmt.Println("Selected INBOX in read-write mode")
 
 	// Get message count in current folder
-	allUIDs, err := m.GetUIDs("ALL")
+	allUIDs, err := m.GetUIDs(ctx, "ALL")
 	if err != nil {
 		return fmt.Errorf("failed to get message count: %w", err)
 	}
 	fmt.Printf("INBOX contains %d messages\n", len(allUIDs))
 
 	// Select folder in read-only mode
-	err = m.ExamineFolder("Sent")
+	err = m.ExamineFolder(ctx, "Sent")
 	if err != nil {
 		return fmt.Errorf("failed to examine Sent folder: %w", err)
 	}
 	fmt.Println("\nExamined Sent folder in read-only mode")
 
-	sentUIDs, err := m.GetUIDs("ALL")
+	sentUIDs, err := m.GetUIDs(ctx, "ALL")
 	if err != nil {
 		return fmt.Errorf("failed to get sent message count: %w", err)
 	}
@@ -61,11 +68,11 @@ func demonstrateFolderSelection(m *imap.Dialer) error {
 	return nil
 }
 
-func demonstrateFolderManagement(m *imap.Dialer) {
+func demonstrateFolderManagement(m *imap.Client) {
 	fmt.Println("\n--- Folder Management ---")
 
 	// Create a new folder
-	err := m.CreateFolder("INBOX/TestFolder")
+	err := m.CreateFolder(ctx, "INBOX/TestFolder")
 	if err != nil {
 		log.Printf("Failed to create folder: %v", err)
 	} else {
@@ -73,7 +80,7 @@ func demonstrateFolderManagement(m *imap.Dialer) {
 	}
 
 	// Rename the folder
-	err = m.RenameFolder("INBOX/TestFolder", "INBOX/RenamedFolder")
+	err = m.RenameFolder(ctx, "INBOX/TestFolder", "INBOX/RenamedFolder")
 	if err != nil {
 		log.Printf("Failed to rename folder: %v", err)
 	} else {
@@ -81,7 +88,7 @@ func demonstrateFolderManagement(m *imap.Dialer) {
 	}
 
 	// Delete the folder
-	err = m.DeleteFolder("INBOX/RenamedFolder")
+	err = m.DeleteFolder(ctx, "INBOX/RenamedFolder")
 	if err != nil {
 		log.Printf("Failed to delete folder: %v", err)
 	} else {
@@ -89,11 +96,11 @@ func demonstrateFolderManagement(m *imap.Dialer) {
 	}
 }
 
-func demonstrateEmailCounts(m *imap.Dialer) error {
+func demonstrateEmailCounts(m *imap.Client) error {
 	fmt.Println("\n--- Email Counts ---")
 
 	// Get total email count across all folders (traditional approach)
-	totalCount, err := m.GetTotalEmailCount()
+	totalCount, err := m.GetTotalEmailCount(ctx)
 	if err != nil {
 		fmt.Printf("Traditional count failed: %v\n", err)
 		fmt.Println("This might happen with Gmail or other providers that have inaccessible system folders")
@@ -102,7 +109,7 @@ func demonstrateEmailCounts(m *imap.Dialer) error {
 	}
 
 	// Get total email count with robust error handling
-	safeCount, folderErrors, err := m.GetTotalEmailCountSafe()
+	safeCount, folderErrors, err := m.GetTotalEmailCountSafe(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get safe total email count: %w", err)
 	}
@@ -117,7 +124,7 @@ func demonstrateEmailCounts(m *imap.Dialer) error {
 
 	// Get count excluding certain folders (safe version)
 	excludedFolders := []string{"Trash", "[Gmail]/Spam", "Junk", "Deleted"}
-	count, folderErrors, err := m.GetTotalEmailCountSafeExcluding(excludedFolders)
+	count, folderErrors, err := m.GetTotalEmailCountSafeExcluding(ctx, excludedFolders)
 	if err != nil {
 		return fmt.Errorf("failed to get filtered email count: %w", err)
 	}
@@ -136,10 +143,10 @@ func demonstrateEmailCounts(m *imap.Dialer) error {
 	return nil
 }
 
-func demonstrateFolderStats(m *imap.Dialer) error {
+func demonstrateFolderStats(m *imap.Client) error {
 	fmt.Println("\n--- Detailed Folder Statistics ---")
 
-	stats, err := m.GetFolderStats()
+	stats, err := m.GetFolderStats(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get folder statistics: %w", err)
 	}

--- a/examples/folders/main.go
+++ b/examples/folders/main.go
@@ -99,21 +99,14 @@ func demonstrateFolderManagement(m *imap.Client) {
 func demonstrateEmailCounts(m *imap.Client) error {
 	fmt.Println("\n--- Email Counts ---")
 
-	// Get total email count across all folders (traditional approach)
-	totalCount, err := m.GetTotalEmailCount(ctx)
+	// Total email count across all folders. Per-folder failures are reported
+	// in folderErrors so that one inaccessible folder (common with Gmail
+	// system folders) does not abort the entire count.
+	totalCount, folderErrors, err := m.TotalEmailCount(ctx, imap.CountOptions{})
 	if err != nil {
-		fmt.Printf("Traditional count failed: %v\n", err)
-		fmt.Println("This might happen with Gmail or other providers that have inaccessible system folders")
-	} else {
-		fmt.Printf("Total emails in all folders: %d\n", totalCount)
+		return fmt.Errorf("failed to get total email count: %w", err)
 	}
-
-	// Get total email count with robust error handling
-	safeCount, folderErrors, err := m.GetTotalEmailCountSafe(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get safe total email count: %w", err)
-	}
-	fmt.Printf("Total emails (safe count): %d\n", safeCount)
+	fmt.Printf("Total emails in all folders: %d\n", totalCount)
 
 	if len(folderErrors) > 0 {
 		fmt.Printf("Note: %d folders had errors:\n", len(folderErrors))
@@ -122,9 +115,10 @@ func demonstrateEmailCounts(m *imap.Client) error {
 		}
 	}
 
-	// Get count excluding certain folders (safe version)
-	excludedFolders := []string{"Trash", "[Gmail]/Spam", "Junk", "Deleted"}
-	count, folderErrors, err := m.GetTotalEmailCountSafeExcluding(ctx, excludedFolders)
+	// Count excluding certain folders.
+	count, folderErrors, err := m.TotalEmailCount(ctx, imap.CountOptions{
+		ExcludeFolders: []string{"Trash", "[Gmail]/Spam", "Junk", "Deleted"},
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get filtered email count: %w", err)
 	}
@@ -134,9 +128,8 @@ func demonstrateEmailCounts(m *imap.Client) error {
 		fmt.Printf("Folders with errors during exclusion count: %d\n", len(folderErrors))
 	}
 
-	// Calculate percentage
-	if safeCount > 0 {
-		percentage := float64(count) / float64(safeCount) * 100
+	if totalCount > 0 {
+		percentage := float64(count) / float64(totalCount) * 100
 		fmt.Printf("That's %.1f%% of your total emails\n", percentage)
 	}
 
@@ -146,7 +139,7 @@ func demonstrateEmailCounts(m *imap.Client) error {
 func demonstrateFolderStats(m *imap.Client) error {
 	fmt.Println("\n--- Detailed Folder Statistics ---")
 
-	stats, err := m.GetFolderStats(ctx)
+	stats, err := m.FolderStats(ctx, imap.CountOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get folder statistics: %w", err)
 	}

--- a/examples/idle_monitoring/main.go
+++ b/examples/idle_monitoring/main.go
@@ -33,11 +33,14 @@ func connectAndSelect() (*imap.Client, error) {
 }
 
 func handleNewEmail(m *imap.Client, e imap.ExistsEvent) {
-	fmt.Printf("[EXISTS] New message arrived! Message index: %d\n", e.MessageIndex)
+	fmt.Printf("[EXISTS] New message arrived! Sequence number: %d\n", e.SeqNum)
 	fmt.Printf("         Timestamp: %s\n", time.Now().Format("15:04:05"))
 	fmt.Printf("         Fetching new email details...\n")
 
-	uids, err := m.GetUIDs(ctx, fmt.Sprintf("%d", e.MessageIndex))
+	// Resolve sequence number -> UID via SEARCH (a bare number in IMAP
+	// SEARCH matches by sequence number). EXISTS reports the new total
+	// count, which equals the sequence number of the newest message.
+	uids, err := m.GetUIDs(ctx, fmt.Sprintf("%d", e.SeqNum))
 	if err != nil || len(uids) == 0 {
 		fmt.Println()
 		return
@@ -82,14 +85,14 @@ func createIdleHandler(m *imap.Client) *imap.IdleHandler {
 		},
 
 		OnExpunge: func(e imap.ExpungeEvent) {
-			fmt.Printf("[EXPUNGE] Message removed at index: %d\n", e.MessageIndex)
+			fmt.Printf("[EXPUNGE] Message removed at sequence number: %d\n", e.SeqNum)
 			fmt.Printf("          Timestamp: %s\n", time.Now().Format("15:04:05"))
 			fmt.Println()
 		},
 
 		OnFetch: func(e imap.FetchEvent) {
 			fmt.Printf("[FETCH] Flags changed\n")
-			fmt.Printf("        Message Index: %d\n", e.MessageIndex)
+			fmt.Printf("        Sequence Number: %d\n", e.SeqNum)
 			fmt.Printf("        UID: %d\n", e.UID)
 			fmt.Printf("        New Flags: %v\n", e.Flags)
 			fmt.Printf("        Timestamp: %s\n", time.Now().Format("15:04:05"))

--- a/examples/idle_monitoring/main.go
+++ b/examples/idle_monitoring/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -11,13 +12,19 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
-func connectAndSelect() (*imap.Dialer, error) {
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+var ctx = context.Background()
+
+func connectAndSelect() (*imap.Client, error) {
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host: "mail.server.com",
+		Port: 993,
+		Auth: imap.PasswordAuth{Username: "username", Password: "password"},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
 
-	if err := m.SelectFolder("INBOX"); err != nil {
+	if err := m.SelectFolder(ctx, "INBOX"); err != nil {
 		_ = m.Close()
 		return nil, fmt.Errorf("failed to select INBOX: %w", err)
 	}
@@ -25,19 +32,19 @@ func connectAndSelect() (*imap.Dialer, error) {
 	return m, nil
 }
 
-func handleNewEmail(m *imap.Dialer, e imap.ExistsEvent) {
+func handleNewEmail(m *imap.Client, e imap.ExistsEvent) {
 	fmt.Printf("[EXISTS] New message arrived! Message index: %d\n", e.MessageIndex)
 	fmt.Printf("         Timestamp: %s\n", time.Now().Format("15:04:05"))
 	fmt.Printf("         Fetching new email details...\n")
 
-	uids, err := m.GetUIDs(fmt.Sprintf("%d", e.MessageIndex))
+	uids, err := m.GetUIDs(ctx, fmt.Sprintf("%d", e.MessageIndex))
 	if err != nil || len(uids) == 0 {
 		fmt.Println()
 		return
 	}
 
 	uid := uids[0]
-	overviews, err := m.GetOverviews(uid)
+	overviews, err := m.GetOverviews(ctx, uid)
 	if err == nil && len(overviews) > 0 {
 		email := overviews[uid]
 		fmt.Printf("         Subject: %s\n", email.Subject)
@@ -68,7 +75,7 @@ func describeFlagChange(flags []string) {
 	}
 }
 
-func createIdleHandler(m *imap.Dialer) *imap.IdleHandler {
+func createIdleHandler(m *imap.Client) *imap.IdleHandler {
 	return &imap.IdleHandler{
 		OnExists: func(e imap.ExistsEvent) {
 			handleNewEmail(m, e)
@@ -92,9 +99,9 @@ func createIdleHandler(m *imap.Dialer) *imap.IdleHandler {
 	}
 }
 
-func printInitialState(m *imap.Dialer) {
-	allUIDs, _ := m.GetUIDs("ALL")
-	unseenUIDs, _ := m.GetUIDs("UNSEEN")
+func printInitialState(m *imap.Client) {
+	allUIDs, _ := m.GetUIDs(ctx, "ALL")
+	unseenUIDs, _ := m.GetUIDs(ctx, "UNSEEN")
 	fmt.Printf("Initial state: %d total emails, %d unread\n", len(allUIDs), len(unseenUIDs))
 	fmt.Println()
 }
@@ -144,7 +151,7 @@ func main() {
 	printIdleInstructions()
 
 	handler := createIdleHandler(m)
-	err = m.StartIdle(handler)
+	err = m.StartIdle(ctx, handler)
 	if err != nil {
 		log.Fatalf("Failed to start IDLE: %v", err)
 	}
@@ -159,7 +166,7 @@ func main() {
 	}
 
 	// Get final state
-	allUIDs, _ := m.GetUIDs("ALL")
-	unseenUIDs, _ := m.GetUIDs("UNSEEN")
+	allUIDs, _ := m.GetUIDs(ctx, "ALL")
+	unseenUIDs, _ := m.GetUIDs(ctx, "UNSEEN")
 	fmt.Printf("\nFinal state: %d total emails, %d unread\n", len(allUIDs), len(unseenUIDs))
 }

--- a/examples/literal_search/main.go
+++ b/examples/literal_search/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -8,13 +9,19 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
+var ctx = context.Background()
+
 func main() {
 	fmt.Println("=== RFC 3501 Section 7.5 Literal Search Example ===")
 	fmt.Println("This example demonstrates searching with non-ASCII characters using literal syntax")
 	fmt.Println()
 
 	// Connect to server
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host: "mail.server.com",
+		Port: 993,
+		Auth: imap.PasswordAuth{Username: "username", Password: "password"},
+	})
 	if err != nil {
 		log.Fatalf("Failed to connect: %v", err)
 	}
@@ -25,7 +32,7 @@ func main() {
 	}()
 
 	// Select folder first
-	err = m.SelectFolder("INBOX")
+	err = m.SelectFolder(ctx, "INBOX")
 	if err != nil {
 		log.Fatalf("Failed to select INBOX: %v", err)
 	}
@@ -81,7 +88,7 @@ func main() {
 		fmt.Printf("   Actual bytes: %d\n", len([]byte(search.query[strings.LastIndex(search.query, "\n")+1:])))
 
 		// Perform the search
-		uids, err := m.GetUIDs(search.query)
+		uids, err := m.GetUIDs(ctx, search.query)
 		if err != nil {
 			fmt.Printf("   ❌ Search failed: %v\n", err)
 		} else if len(uids) == 0 {
@@ -105,7 +112,7 @@ func main() {
 
 	for _, search := range asciiSearches {
 		fmt.Printf("Query: %s\n", search)
-		uids, err := m.GetUIDs(search)
+		uids, err := m.GetUIDs(ctx, search)
 		if err != nil {
 			fmt.Printf("❌ Search failed: %v\n", err)
 		} else {

--- a/examples/oauth2_connection/main.go
+++ b/examples/oauth2_connection/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -8,17 +9,22 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
-func main() {
-	imap.DialTimeout = 10 * time.Second
-	imap.CommandTimeout = 30 * time.Second
+var ctx = context.Background()
 
+func main() {
 	// OAuth2 access token - you need to obtain this from your OAuth2 flow
 	// For Gmail: https://developers.google.com/gmail/api/auth/about-auth
 	// For Office 365: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
 	accessToken := "your-oauth2-access-token"
 
 	// Connect with OAuth2 (Gmail example)
-	m, err := imap.NewWithOAuth2("user@example.com", accessToken, "imap.gmail.com", 993)
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host:           "imap.gmail.com",
+		Port:           993,
+		Auth:           imap.XOAuth2{Username: "user@example.com", AccessToken: accessToken},
+		DialTimeout:    10 * time.Second,
+		CommandTimeout: 30 * time.Second,
+	})
 	if err != nil {
 		log.Fatalf("Failed to connect with OAuth2: %v", err)
 	}
@@ -29,11 +35,11 @@ func main() {
 	}()
 
 	// The OAuth2 connection works exactly like LOGIN after authentication
-	if err := m.SelectFolder("INBOX"); err != nil {
+	if err := m.SelectFolder(ctx, "INBOX"); err != nil {
 		log.Fatalf("Failed to select INBOX: %v", err)
 	}
 
-	unreadUIDs, err := m.GetUIDs("UNSEEN")
+	unreadUIDs, err := m.GetUIDs(ctx, "UNSEEN")
 	if err != nil {
 		log.Fatalf("Failed to search for unread emails: %v", err)
 	}

--- a/examples/search/main.go
+++ b/examples/search/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -8,9 +9,15 @@ import (
 	imap "github.com/BrianLeishman/go-imap"
 )
 
+var ctx = context.Background()
+
 func main() {
 	// Connect to server
-	m, err := imap.New("username", "password", "mail.server.com", 993)
+	m, err := imap.Dial(context.Background(), imap.Options{
+		Host: "mail.server.com",
+		Port: 993,
+		Auth: imap.PasswordAuth{Username: "username", Password: "password"},
+	})
 	if err != nil {
 		log.Fatalf("Failed to connect: %v", err)
 	}
@@ -20,7 +27,7 @@ func main() {
 		}
 	}()
 
-	err = m.SelectFolder("INBOX")
+	err = m.SelectFolder(ctx, "INBOX")
 	if err != nil {
 		log.Fatalf("Failed to select INBOX: %v", err)
 	}
@@ -28,11 +35,11 @@ func main() {
 	fmt.Println("=== Basic Searches ===")
 
 	// Basic searches - returns slice of UIDs
-	allUIDs, _ := m.GetUIDs("ALL")         // All emails
-	unseenUIDs, _ := m.GetUIDs("UNSEEN")   // Unread emails
-	recentUIDs, _ := m.GetUIDs("RECENT")   // Recent emails
-	seenUIDs, _ := m.GetUIDs("SEEN")       // Read emails
-	flaggedUIDs, _ := m.GetUIDs("FLAGGED") // Starred/flagged emails
+	allUIDs, _ := m.GetUIDs(ctx, "ALL")         // All emails
+	unseenUIDs, _ := m.GetUIDs(ctx, "UNSEEN")   // Unread emails
+	recentUIDs, _ := m.GetUIDs(ctx, "RECENT")   // Recent emails
+	seenUIDs, _ := m.GetUIDs(ctx, "SEEN")       // Read emails
+	flaggedUIDs, _ := m.GetUIDs(ctx, "FLAGGED") // Starred/flagged emails
 
 	fmt.Printf("Found %d total emails\n", len(allUIDs))
 	fmt.Printf("Found %d unread emails\n", len(unseenUIDs))
@@ -52,10 +59,10 @@ func main() {
 	weekAgo := time.Now().AddDate(0, 0, -7).Format("2-Jan-2006")
 	monthAgo := time.Now().AddDate(0, -1, 0).Format("2-Jan-2006")
 
-	todayUIDs, _ := m.GetUIDs(fmt.Sprintf("ON %s", today))
-	sinceUIDs, _ := m.GetUIDs(fmt.Sprintf("SINCE %s", weekAgo))
-	beforeUIDs, _ := m.GetUIDs(fmt.Sprintf("BEFORE %s", today))
-	rangeUIDs, _ := m.GetUIDs(fmt.Sprintf("SINCE %s BEFORE %s", monthAgo, today))
+	todayUIDs, _ := m.GetUIDs(ctx, fmt.Sprintf("ON %s", today))
+	sinceUIDs, _ := m.GetUIDs(ctx, fmt.Sprintf("SINCE %s", weekAgo))
+	beforeUIDs, _ := m.GetUIDs(ctx, fmt.Sprintf("BEFORE %s", today))
+	rangeUIDs, _ := m.GetUIDs(ctx, fmt.Sprintf("SINCE %s BEFORE %s", monthAgo, today))
 
 	fmt.Printf("Emails from today: %d\n", len(todayUIDs))
 	fmt.Printf("Emails since a week ago: %d\n", len(sinceUIDs))
@@ -65,9 +72,9 @@ func main() {
 	fmt.Println("\n=== Sender/Recipient Searches ===")
 
 	// From/To searches
-	fromBossUIDs, _ := m.GetUIDs(`FROM "boss@company.com"`)
-	toMeUIDs, _ := m.GetUIDs(`TO "me@company.com"`)
-	ccUIDs, _ := m.GetUIDs(`CC "team@company.com"`)
+	fromBossUIDs, _ := m.GetUIDs(ctx, `FROM "boss@company.com"`)
+	toMeUIDs, _ := m.GetUIDs(ctx, `TO "me@company.com"`)
+	ccUIDs, _ := m.GetUIDs(ctx, `CC "team@company.com"`)
 
 	fmt.Printf("Emails from boss: %d\n", len(fromBossUIDs))
 	fmt.Printf("Emails to me: %d\n", len(toMeUIDs))
@@ -76,9 +83,9 @@ func main() {
 	fmt.Println("\n=== Content Searches ===")
 
 	// Subject/body searches
-	subjectUIDs, _ := m.GetUIDs(`SUBJECT "invoice"`)
-	bodyUIDs, _ := m.GetUIDs(`BODY "payment"`)
-	textUIDs, _ := m.GetUIDs(`TEXT "urgent"`) // Searches both subject and body
+	subjectUIDs, _ := m.GetUIDs(ctx, `SUBJECT "invoice"`)
+	bodyUIDs, _ := m.GetUIDs(ctx, `BODY "payment"`)
+	textUIDs, _ := m.GetUIDs(ctx, `TEXT "urgent"`) // Searches both subject and body
 
 	fmt.Printf("Emails with 'invoice' in subject: %d\n", len(subjectUIDs))
 	fmt.Printf("Emails with 'payment' in body: %d\n", len(bodyUIDs))
@@ -86,9 +93,9 @@ func main() {
 
 	fmt.Println("\n=== Complex Searches ===")
 
-	complexUIDs1, _ := m.GetUIDs(`UNSEEN FROM "support@github.com" SINCE 1-Jan-2024`)
-	complexUIDs2, _ := m.GetUIDs(`FLAGGED SUBJECT "important" SINCE 1-Jan-2024`)
-	complexUIDs3, _ := m.GetUIDs(`NOT SEEN NOT FROM "noreply@" SINCE 1-Jan-2024`)
+	complexUIDs1, _ := m.GetUIDs(ctx, `UNSEEN FROM "support@github.com" SINCE 1-Jan-2024`)
+	complexUIDs2, _ := m.GetUIDs(ctx, `FLAGGED SUBJECT "important" SINCE 1-Jan-2024`)
+	complexUIDs3, _ := m.GetUIDs(ctx, `NOT SEEN NOT FROM "noreply@" SINCE 1-Jan-2024`)
 
 	fmt.Printf("Unread emails from GitHub support this year: %d\n", len(complexUIDs1))
 	fmt.Printf("Flagged emails with 'important' in subject this year: %d\n", len(complexUIDs2))
@@ -96,11 +103,11 @@ func main() {
 
 	fmt.Println("\n=== UID Ranges ===")
 
-	firstUID, _ := m.GetUIDs("1")       // First email
-	lastUID, _ := m.GetUIDs("*")        // Last email
-	maxUID, err := m.GetMaxUID()        // Last email (cheaper, requires RFC-4731)
-	first10UIDs, _ := m.GetUIDs("1:10") // First 10 emails
-	last10UIDs, _ := m.GetUIDs("*:10")  // Last 10 emails (reverse)
+	firstUID, _ := m.GetUIDs(ctx, "1")       // First email
+	lastUID, _ := m.GetUIDs(ctx, "*")        // Last email
+	maxUID, err := m.GetMaxUID(ctx)        // Last email (cheaper, requires RFC-4731)
+	first10UIDs, _ := m.GetUIDs(ctx, "1:10") // First 10 emails
+	last10UIDs, _ := m.GetUIDs(ctx, "*:10")  // Last 10 emails (reverse)
 
 	fmt.Printf("First email UID: %v\n", firstUID)
 	fmt.Printf("Last email UID: %v\n", lastUID)
@@ -119,9 +126,9 @@ func main() {
 	fmt.Println("\n=== Size-based Searches ===")
 
 	// Size-based searches (in bytes)
-	largeUIDs, _ := m.GetUIDs("LARGER 10485760") // Emails larger than 10MB
-	mediumUIDs, _ := m.GetUIDs("LARGER 1048576") // Emails larger than 1MB
-	smallUIDs, _ := m.GetUIDs("SMALLER 10240")   // Emails smaller than 10KB
+	largeUIDs, _ := m.GetUIDs(ctx, "LARGER 10485760") // Emails larger than 10MB
+	mediumUIDs, _ := m.GetUIDs(ctx, "LARGER 1048576") // Emails larger than 1MB
+	smallUIDs, _ := m.GetUIDs(ctx, "SMALLER 10240")   // Emails smaller than 10KB
 
 	fmt.Printf("Emails larger than 10MB: %d\n", len(largeUIDs))
 	fmt.Printf("Emails larger than 1MB: %d\n", len(mediumUIDs))
@@ -130,18 +137,18 @@ func main() {
 	fmt.Println("\n=== Search Builder (Type-Safe API) ===")
 
 	// The SearchBuilder provides a fluent, type-safe alternative to raw strings
-	unseenBuilderUIDs, _ := m.SearchUIDs(imap.Search().Unseen())
+	unseenBuilderUIDs, _ := m.SearchUIDs(ctx, imap.Search().Unseen())
 	fmt.Printf("Unread emails (builder): %d\n", len(unseenBuilderUIDs))
 
 	// Combine multiple criteria
 	weekAgoTime := time.Now().AddDate(0, 0, -7)
-	recentUnread, _ := m.SearchUIDs(
+	recentUnread, _ := m.SearchUIDs(ctx, 
 		imap.Search().Unseen().Since(weekAgoTime),
 	)
 	fmt.Printf("Unread emails from last 7 days (builder): %d\n", len(recentUnread))
 
 	// OR: messages from either sender
-	fromEither, _ := m.SearchUIDs(
+	fromEither, _ := m.SearchUIDs(ctx, 
 		imap.Search().Or(
 			imap.Search().From("boss@company.com"),
 			imap.Search().From("support@github.com"),
@@ -150,13 +157,13 @@ func main() {
 	fmt.Printf("Emails from boss or GitHub support: %d\n", len(fromEither))
 
 	// NOT: exclude certain senders
-	notNoreply, _ := m.SearchUIDs(
+	notNoreply, _ := m.SearchUIDs(ctx, 
 		imap.Search().Not(imap.Search().From("noreply@")).Unseen(),
 	)
 	fmt.Printf("Unread emails NOT from noreply: %d\n", len(notNoreply))
 
 	// Size filter
-	largeBuilder, _ := m.SearchUIDs(imap.Search().Larger(1048576))
+	largeBuilder, _ := m.SearchUIDs(ctx, imap.Search().Larger(1048576))
 	fmt.Printf("Emails larger than 1MB (builder): %d\n", len(largeBuilder))
 
 	// You can also get the raw string from a builder
@@ -165,12 +172,12 @@ func main() {
 
 	fmt.Println("\n=== Special Searches ===")
 
-	answeredUIDs, _ := m.GetUIDs("ANSWERED")
-	unansweredUIDs, _ := m.GetUIDs("UNANSWERED")
-	deletedUIDs, _ := m.GetUIDs("DELETED")
-	undeletedUIDs, _ := m.GetUIDs("UNDELETED")
-	draftUIDs, _ := m.GetUIDs("DRAFT")
-	undraftUIDs, _ := m.GetUIDs("UNDRAFT")
+	answeredUIDs, _ := m.GetUIDs(ctx, "ANSWERED")
+	unansweredUIDs, _ := m.GetUIDs(ctx, "UNANSWERED")
+	deletedUIDs, _ := m.GetUIDs(ctx, "DELETED")
+	undeletedUIDs, _ := m.GetUIDs(ctx, "UNDELETED")
+	draftUIDs, _ := m.GetUIDs(ctx, "DRAFT")
+	undraftUIDs, _ := m.GetUIDs(ctx, "UNDRAFT")
 
 	fmt.Printf("Answered emails: %d\n", len(answeredUIDs))
 	fmt.Printf("Unanswered emails: %d\n", len(unansweredUIDs))

--- a/exec.go
+++ b/exec.go
@@ -148,7 +148,7 @@ func (d *Client) execOnce(ctx context.Context, command string, buildResponse boo
 		oklen := 3
 		if len(line) >= taglen+oklen && bytes.Equal(line[:taglen], tag) {
 			if !bytes.Equal(line[taglen+1:taglen+oklen], []byte("OK")) {
-				return resp, fmt.Errorf("imap command failed: %s", line[taglen+oklen+1:])
+				return resp, parseCommandError(string(tag), commandVerb(command), line[taglen+1:])
 			}
 			break
 		}

--- a/exec.go
+++ b/exec.go
@@ -217,8 +217,7 @@ func (d *Client) Exec(ctx context.Context, command string, buildResponse bool, r
 
 	if buildResponse {
 		if resp.Len() != 0 {
-			lastResp = resp.String()
-			return lastResp, nil
+			return resp.String(), nil
 		}
 		return "", nil
 	}

--- a/exec.go
+++ b/exec.go
@@ -14,6 +14,35 @@ import (
 	"github.com/rs/xid"
 )
 
+// sanitizeCommand redacts credential material from a command line before it
+// is logged. It strips the argument list after AUTHENTICATE <mech> (which
+// carries the raw XOAUTH2 token or SASL payload) and replaces any occurrence
+// of the stored secret — whether quoted or bare — with "****".
+func sanitizeCommand(command, secret string) string {
+	// Redact AUTHENTICATE payloads (e.g., the base64 XOAUTH2 blob which is
+	// sent unquoted and is not caught by substring replacement).
+	if idx := strings.Index(strings.ToUpper(command), "AUTHENTICATE "); idx >= 0 {
+		mechStart := idx + len("AUTHENTICATE ")
+		if space := strings.IndexByte(command[mechStart:], ' '); space >= 0 {
+			return command[:mechStart+space+1] + "****"
+		}
+	}
+	if secret == "" {
+		return command
+	}
+	// Replace the secret in quoted, escaped-quoted, and bare forms. LOGIN
+	// applies addSlashes to username/password before sending, so a secret
+	// containing a quote appears on the wire (and in the log buffer) as
+	// \"; match both shapes so the redaction isn't bypassed.
+	escaped := addSlashes.Replace(secret)
+	out := strings.ReplaceAll(command, `"`+escaped+`"`, `"****"`)
+	if escaped != secret {
+		out = strings.ReplaceAll(out, escaped, "****")
+	}
+	out = strings.ReplaceAll(out, `"`+secret+`"`, `"****"`)
+	return strings.ReplaceAll(out, secret, "****")
+}
+
 // readLiterals reads IMAP literal continuations appended to a response line.
 // It repeatedly checks for {NNN} or {NNN+} patterns at the end of the line,
 // reads the literal data, and appends it.
@@ -112,8 +141,7 @@ func (d *Client) execOnce(ctx context.Context, command string, buildResponse boo
 	c := fmt.Sprintf("%s %s\r\n", tag, command)
 
 	if Verbose {
-		sanitized := strings.ReplaceAll(strings.TrimSpace(c), fmt.Sprintf(`"%s"`, d.password), `"****"`)
-		debugLog(d.ConnNum, d.Folder, "sending command", "command", sanitized)
+		debugLog(d.ConnNum, d.Folder, "sending command", "command", sanitizeCommand(strings.TrimSpace(c), d.password))
 	}
 
 	if _, err := d.conn.Write([]byte(c)); err != nil {

--- a/exec.go
+++ b/exec.go
@@ -62,13 +62,17 @@ func (d *Client) deadlineFromCtx(ctx context.Context) (time.Time, bool) {
 // watchCtxCancel spawns a goroutine that forces the connection's deadline
 // into the past when ctx is canceled, causing any blocked read/write to
 // return promptly. The returned stop function must be called when the
-// command completes to tear the watchdog down.
+// command completes to tear the watchdog down. stop blocks until the
+// watchdog goroutine has exited so it cannot race with a subsequent
+// SetDeadline reset.
 func (d *Client) watchCtxCancel(ctx context.Context) (stop func()) {
 	if ctx.Done() == nil {
 		return func() {}
 	}
 	done := make(chan struct{})
+	exited := make(chan struct{})
 	go func() {
+		defer close(exited)
 		select {
 		case <-ctx.Done():
 			// time.Unix(1, 0) is well in the past; any in-flight I/O
@@ -77,7 +81,10 @@ func (d *Client) watchCtxCancel(ctx context.Context) (stop func()) {
 		case <-done:
 		}
 	}()
-	return func() { close(done) }
+	return func() {
+		close(done)
+		<-exited
+	}
 }
 
 // execOnce runs a single attempt of an IMAP command
@@ -89,13 +96,18 @@ func (d *Client) execOnce(ctx context.Context, command string, buildResponse boo
 		return resp, err
 	}
 
+	// Stop the watchdog and clear any deadline (whether set explicitly above
+	// or by the watchdog on cancellation) before returning, so a late ctx
+	// cancel can't leave the socket poisoned with an expired deadline.
+	stop := d.watchCtxCancel(ctx)
+	defer func() {
+		stop()
+		_ = d.conn.SetDeadline(time.Time{})
+	}()
+
 	if deadline, ok := d.deadlineFromCtx(ctx); ok {
 		_ = d.conn.SetDeadline(deadline)
-		defer func() { _ = d.conn.SetDeadline(time.Time{}) }()
 	}
-
-	stop := d.watchCtxCancel(ctx)
-	defer stop()
 
 	c := fmt.Sprintf("%s %s\r\n", tag, command)
 

--- a/exec.go
+++ b/exec.go
@@ -3,6 +3,7 @@ package imap
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strconv"
@@ -45,25 +46,66 @@ func readLiterals(r *bufio.Reader, line []byte) ([]byte, error) {
 	}
 }
 
+// deadlineFromCtx picks the effective read/write deadline for a command.
+// ctx deadline wins when present; otherwise fall back to the client's
+// configured CommandTimeout (or the package-level default).
+func (d *Client) deadlineFromCtx(ctx context.Context) (time.Time, bool) {
+	if deadline, ok := ctx.Deadline(); ok {
+		return deadline, true
+	}
+	if timeout := d.effectiveCommandTimeout(); timeout > 0 {
+		return time.Now().Add(timeout), true
+	}
+	return time.Time{}, false
+}
+
+// watchCtxCancel spawns a goroutine that forces the connection's deadline
+// into the past when ctx is canceled, causing any blocked read/write to
+// return promptly. The returned stop function must be called when the
+// command completes to tear the watchdog down.
+func (d *Client) watchCtxCancel(ctx context.Context) (stop func()) {
+	if ctx.Done() == nil {
+		return func() {}
+	}
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			// time.Unix(1, 0) is well in the past; any in-flight I/O
+			// unblocks with a timeout error.
+			_ = d.conn.SetDeadline(time.Unix(1, 0))
+		case <-done:
+		}
+	}()
+	return func() { close(done) }
+}
+
 // execOnce runs a single attempt of an IMAP command
-func (d *Dialer) execOnce(command string, buildResponse bool, processLine func(line []byte) error) (strings.Builder, error) {
+func (d *Client) execOnce(ctx context.Context, command string, buildResponse bool, processLine func(line []byte) error) (strings.Builder, error) {
 	tag := []byte(strings.ToUpper(xid.New().String()))
 	var resp strings.Builder
 
-	if CommandTimeout != 0 {
-		_ = d.conn.SetDeadline(time.Now().Add(CommandTimeout))
+	if err := ctx.Err(); err != nil {
+		return resp, err
+	}
+
+	if deadline, ok := d.deadlineFromCtx(ctx); ok {
+		_ = d.conn.SetDeadline(deadline)
 		defer func() { _ = d.conn.SetDeadline(time.Time{}) }()
 	}
+
+	stop := d.watchCtxCancel(ctx)
+	defer stop()
 
 	c := fmt.Sprintf("%s %s\r\n", tag, command)
 
 	if Verbose {
-		sanitized := strings.ReplaceAll(strings.TrimSpace(c), fmt.Sprintf(`"%s"`, d.Password), `"****"`)
+		sanitized := strings.ReplaceAll(strings.TrimSpace(c), fmt.Sprintf(`"%s"`, d.password), `"****"`)
 		debugLog(d.ConnNum, d.Folder, "sending command", "command", sanitized)
 	}
 
 	if _, err := d.conn.Write([]byte(c)); err != nil {
-		return resp, err
+		return resp, wrapCtxErr(ctx, err)
 	}
 
 	r := bufio.NewReader(d.conn)
@@ -75,10 +117,14 @@ func (d *Dialer) execOnce(command string, buildResponse bool, processLine func(l
 	var line []byte
 	for readErr == nil {
 		line, readErr = r.ReadBytes('\n')
+		if readErr != nil {
+			readErr = wrapCtxErr(ctx, readErr)
+			break
+		}
 		var litErr error
 		line, litErr = readLiterals(r, line)
 		if litErr != nil {
-			return resp, litErr
+			return resp, wrapCtxErr(ctx, litErr)
 		}
 
 		if Verbose && !SkipResponses {
@@ -107,11 +153,41 @@ func (d *Dialer) execOnce(command string, buildResponse bool, processLine func(l
 	return resp, readErr
 }
 
-// Exec executes an IMAP command with retry logic and response building
-func (d *Dialer) Exec(command string, buildResponse bool, retryCount int, processLine func(line []byte) error) (response string, err error) {
+// wrapCtxErr replaces an I/O error with ctx.Err() when the context has been
+// canceled or its deadline exceeded. The underlying I/O error is often a
+// generic "use of closed connection" or timeout that hides the cancellation
+// from the caller.
+func wrapCtxErr(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if cerr := ctx.Err(); cerr != nil {
+		return cerr
+	}
+	return err
+}
+
+// Exec executes an IMAP command with retry logic and response building.
+func (d *Client) Exec(ctx context.Context, command string, buildResponse bool, retryCount int, processLine func(line []byte) error) (response string, err error) {
 	var resp strings.Builder
 	err = retry.Retry(func() (err error) {
-		resp, err = d.execOnce(command, buildResponse, processLine)
+		if cerr := ctx.Err(); cerr != nil {
+			return &retry.PermFail{Err: cerr}
+		}
+		resp, err = d.execOnce(ctx, command, buildResponse, processLine)
+		// If ctx was canceled mid-flight, the forced past-deadline aborts
+		// I/O but leaves the protocol stream potentially dirty (the
+		// tagged response may still be in-flight) and leaves the socket
+		// deadline stuck in the past. Close the connection so the next
+		// call reconnects cleanly, and surface ctx.Err() as permanent so
+		// callers can errors.Is against context.Canceled /
+		// context.DeadlineExceeded without a silent retry first.
+		if err != nil {
+			if cerr := ctx.Err(); cerr != nil {
+				_ = d.Close()
+				return &retry.PermFail{Err: cerr}
+			}
+		}
 		return err
 	}, retryCount, func(err error) error {
 		if Verbose {
@@ -120,7 +196,7 @@ func (d *Dialer) Exec(command string, buildResponse bool, retryCount int, proces
 		_ = d.Close()
 		return nil
 	}, func() error {
-		return d.Reconnect()
+		return d.Reconnect(ctx)
 	})
 	if err != nil {
 		errorLog(d.ConnNum, d.Folder, "command retries exhausted", "error", err)

--- a/folder.go
+++ b/folder.go
@@ -6,14 +6,25 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"time"
 )
 
-// FolderStats represents statistics for a folder
-type FolderStats struct {
+// FolderStat represents statistics for a single folder.
+type FolderStat struct {
 	Name   string
 	Count  int
 	MaxUID UID
 	Error  error
+}
+
+// CountOptions configures folder iteration for TotalEmailCount and FolderStats.
+// The zero value walks every folder.
+type CountOptions struct {
+	// StartFolder skips folders returned by LIST before this one (matched by
+	// exact name). An empty value starts at the first folder.
+	StartFolder string
+	// ExcludeFolders names folders to skip entirely.
+	ExcludeFolders []string
 }
 
 // GetFolders retrieves the list of available folders.
@@ -134,123 +145,35 @@ func (d *Client) RenameFolder(ctx context.Context, oldName, newName string) erro
 	return nil
 }
 
-// GetTotalEmailCount returns the total email count across all folders.
-func (d *Client) GetTotalEmailCount(ctx context.Context) (count int, err error) {
-	return d.GetTotalEmailCountStartingFromExcluding(ctx, "", nil)
-}
-
-// GetTotalEmailCountExcluding returns total email count excluding specified folders.
-func (d *Client) GetTotalEmailCountExcluding(ctx context.Context, excludedFolders []string) (count int, err error) {
-	return d.GetTotalEmailCountStartingFromExcluding(ctx, "", excludedFolders)
-}
-
-// GetTotalEmailCountStartingFrom returns total email count starting from a specific folder.
-func (d *Client) GetTotalEmailCountStartingFrom(ctx context.Context, startFolder string) (count int, err error) {
-	return d.GetTotalEmailCountStartingFromExcluding(ctx, startFolder, nil)
-}
-
-// GetTotalEmailCountSafe returns total email count with error handling per folder.
-func (d *Client) GetTotalEmailCountSafe(ctx context.Context) (count int, folderErrors []error, err error) {
-	return d.GetTotalEmailCountSafeStartingFromExcluding(ctx, "", nil)
-}
-
-// GetTotalEmailCountSafeExcluding returns total email count excluding folders with error handling.
-func (d *Client) GetTotalEmailCountSafeExcluding(ctx context.Context, excludedFolders []string) (count int, folderErrors []error, err error) {
-	return d.GetTotalEmailCountSafeStartingFromExcluding(ctx, "", excludedFolders)
-}
-
-// GetTotalEmailCountSafeStartingFrom returns total email count starting from folder with error handling.
-func (d *Client) GetTotalEmailCountSafeStartingFrom(ctx context.Context, startFolder string) (count int, folderErrors []error, err error) {
-	return d.GetTotalEmailCountSafeStartingFromExcluding(ctx, startFolder, nil)
-}
-
-// GetFolderStats returns statistics for all folders.
-func (d *Client) GetFolderStats(ctx context.Context) ([]FolderStats, error) {
-	return d.GetFolderStatsStartingFromExcluding(ctx, "", nil)
-}
-
-// GetFolderStatsExcluding returns statistics for folders excluding specified ones.
-func (d *Client) GetFolderStatsExcluding(ctx context.Context, excludedFolders []string) ([]FolderStats, error) {
-	return d.GetFolderStatsStartingFromExcluding(ctx, "", excludedFolders)
-}
-
-// GetFolderStatsStartingFrom returns statistics for folders starting from a specific one.
-func (d *Client) GetFolderStatsStartingFrom(ctx context.Context, startFolder string) ([]FolderStats, error) {
-	return d.GetFolderStatsStartingFromExcluding(ctx, startFolder, nil)
-}
-
-// GetTotalEmailCountStartingFromExcluding returns total email count with options for starting folder and exclusions.
-func (d *Client) GetTotalEmailCountStartingFromExcluding(ctx context.Context, startFolder string, excludedFolders []string) (count int, err error) {
-	folders, err := d.GetFolders(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	startFound := startFolder == ""
-	excludeMap := make(map[string]bool)
-	for _, folder := range excludedFolders {
-		excludeMap[folder] = true
-	}
-
-	currentFolder := d.Folder
-	currentReadOnly := d.ReadOnly
-
-	for _, folder := range folders {
-		if !startFound {
-			if folder == startFolder {
-				startFound = true
-			} else {
-				continue
-			}
-		}
-
-		if excludeMap[folder] {
-			continue
-		}
-
-		folderCount, err := d.selectAndGetCount(ctx, folder)
-		if err == nil {
-			count += folderCount
-		}
-	}
-
-	// Restore original folder state
-	if currentFolder != "" {
-		if currentReadOnly {
-			_ = d.ExamineFolder(ctx, currentFolder)
-		} else {
-			_ = d.SelectFolder(ctx, currentFolder)
-		}
-	}
-
-	return count, nil
-}
-
-// GetTotalEmailCountSafeStartingFromExcluding returns total email count with per-folder error handling.
-func (d *Client) GetTotalEmailCountSafeStartingFromExcluding(ctx context.Context, startFolder string, excludedFolders []string) (count int, folderErrors []error, err error) {
+// TotalEmailCount sums message counts across folders. Per-folder failures
+// are reported in folderErrors but do not abort iteration. err is non-nil
+// if the initial folder list could not be retrieved or if ctx is cancelled
+// mid-iteration; in the latter case count and folderErrors hold the
+// partial result accumulated before cancellation.
+func (d *Client) TotalEmailCount(ctx context.Context, opts CountOptions) (count int, folderErrors []error, err error) {
 	folders, err := d.GetFolders(ctx)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	startFound := startFolder == ""
-	excludeMap := make(map[string]bool)
-	for _, folder := range excludedFolders {
+	excludeMap := make(map[string]bool, len(opts.ExcludeFolders))
+	for _, folder := range opts.ExcludeFolders {
 		excludeMap[folder] = true
 	}
 
-	currentFolder := d.Folder
-	currentReadOnly := d.ReadOnly
+	defer d.restoreSelection(ctx, d.Folder, d.ReadOnly)
 
+	startFound := opts.StartFolder == ""
 	for _, folder := range folders {
+		if cerr := ctx.Err(); cerr != nil {
+			return count, folderErrors, cerr
+		}
 		if !startFound {
-			if folder == startFolder {
-				startFound = true
-			} else {
+			if folder != opts.StartFolder {
 				continue
 			}
+			startFound = true
 		}
-
 		if excludeMap[folder] {
 			continue
 		}
@@ -263,52 +186,42 @@ func (d *Client) GetTotalEmailCountSafeStartingFromExcluding(ctx context.Context
 		count += folderCount
 	}
 
-	// Restore original folder state
-	if currentFolder != "" {
-		if currentReadOnly {
-			_ = d.ExamineFolder(ctx, currentFolder)
-		} else {
-			_ = d.SelectFolder(ctx, currentFolder)
-		}
-	}
-
 	return count, folderErrors, nil
 }
 
-// GetFolderStatsStartingFromExcluding returns detailed statistics for folders with options.
-func (d *Client) GetFolderStatsStartingFromExcluding(ctx context.Context, startFolder string, excludedFolders []string) ([]FolderStats, error) {
+// FolderStats returns per-folder statistics. Per-folder failures are reported
+// in FolderStat.Error rather than aborting the iteration. If ctx is cancelled
+// mid-iteration the partial slice is returned with ctx.Err().
+func (d *Client) FolderStats(ctx context.Context, opts CountOptions) ([]FolderStat, error) {
 	folders, err := d.GetFolders(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	startFound := startFolder == ""
-	excludeMap := make(map[string]bool)
-	for _, folder := range excludedFolders {
+	excludeMap := make(map[string]bool, len(opts.ExcludeFolders))
+	for _, folder := range opts.ExcludeFolders {
 		excludeMap[folder] = true
 	}
 
-	currentFolder := d.Folder
-	currentReadOnly := d.ReadOnly
+	defer d.restoreSelection(ctx, d.Folder, d.ReadOnly)
 
-	var stats []FolderStats
-
+	var stats []FolderStat
+	startFound := opts.StartFolder == ""
 	for _, folder := range folders {
+		if cerr := ctx.Err(); cerr != nil {
+			return stats, cerr
+		}
 		if !startFound {
-			if folder == startFolder {
-				startFound = true
-			} else {
+			if folder != opts.StartFolder {
 				continue
 			}
+			startFound = true
 		}
-
 		if excludeMap[folder] {
 			continue
 		}
 
-		stat := FolderStats{Name: folder}
-
-		// Get message count using helper function
+		stat := FolderStat{Name: folder}
 		count, err := d.selectAndGetCount(ctx, folder)
 		if err != nil {
 			stat.Error = err
@@ -317,7 +230,6 @@ func (d *Client) GetFolderStatsStartingFromExcluding(ctx context.Context, startF
 		}
 		stat.Count = count
 
-		// Get highest UID
 		if stat.Count > 0 {
 			uidResponse, err := d.Exec(ctx, "UID SEARCH ALL", true, d.effectiveRetryCount(), nil)
 			if err == nil {
@@ -331,14 +243,32 @@ func (d *Client) GetFolderStatsStartingFromExcluding(ctx context.Context, startF
 		stats = append(stats, stat)
 	}
 
-	// Restore original folder state
-	if currentFolder != "" {
-		if currentReadOnly {
-			_ = d.ExamineFolder(ctx, currentFolder)
-		} else {
-			_ = d.SelectFolder(ctx, currentFolder)
-		}
-	}
-
 	return stats, nil
+}
+
+// restoreSelection re-selects the previously selected folder (if any) using
+// the original read-only/read-write mode. The caller's context cancellation
+// is intentionally detached so a cancelled or timed-out iteration does not
+// leave the client selected on an unrelated mailbox; an explicit cleanup
+// deadline still bounds the SELECT/EXAMINE so a stalled server cannot
+// block the call forever.
+func (d *Client) restoreSelection(ctx context.Context, folder string, readOnly bool) {
+	if folder == "" {
+		return
+	}
+	restoreCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+	if readOnly {
+		_ = d.ExamineFolder(restoreCtx, folder)
+	} else {
+		_ = d.SelectFolder(restoreCtx, folder)
+	}
+}
+
+// cleanupContext returns a derived context suitable for best-effort cleanup
+// after the caller's ctx has been cancelled or timed out. Cancellation is
+// detached (so the cleanup runs to completion) but a fallback deadline is
+// applied so a stalled server cannot hang the cleanup indefinitely.
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 }

--- a/folder.go
+++ b/folder.go
@@ -2,6 +2,7 @@ package imap
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -15,10 +16,10 @@ type FolderStats struct {
 	Error  error
 }
 
-// GetFolders retrieves the list of available folders
-func (d *Dialer) GetFolders() (folders []string, err error) {
+// GetFolders retrieves the list of available folders.
+func (d *Client) GetFolders(ctx context.Context) (folders []string, err error) {
 	folders = make([]string, 0)
-	_, err = d.Exec(`LIST "" "*"`, false, RetryCount, func(line []byte) (err error) {
+	_, err = d.Exec(ctx, `LIST "" "*"`, false, d.effectiveRetryCount(), func(line []byte) (err error) {
 		line = dropNl(line)
 		if b := bytes.IndexByte(line, '\n'); b != -1 {
 			folders = append(folders, string(line[b+1:]))
@@ -53,9 +54,9 @@ func (d *Dialer) GetFolders() (folders []string, err error) {
 	return folders, nil
 }
 
-// ExamineFolder selects a folder in read-only mode
-func (d *Dialer) ExamineFolder(folder string) (err error) {
-	_, err = d.Exec(`EXAMINE "`+AddSlashes.Replace(folder)+`"`, true, RetryCount, nil)
+// ExamineFolder selects a folder in read-only mode.
+func (d *Client) ExamineFolder(ctx context.Context, folder string) error {
+	_, err := d.Exec(ctx, `EXAMINE "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return err
 	}
@@ -64,9 +65,9 @@ func (d *Dialer) ExamineFolder(folder string) (err error) {
 	return nil
 }
 
-// SelectFolder selects a folder in read-write mode
-func (d *Dialer) SelectFolder(folder string) (err error) {
-	_, err = d.Exec(`SELECT "`+AddSlashes.Replace(folder)+`"`, true, RetryCount, nil)
+// SelectFolder selects a folder in read-write mode.
+func (d *Client) SelectFolder(ctx context.Context, folder string) error {
+	_, err := d.Exec(ctx, `SELECT "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return err
 	}
@@ -75,9 +76,9 @@ func (d *Dialer) SelectFolder(folder string) (err error) {
 	return nil
 }
 
-// selectAndGetCount executes SELECT command and extracts message count from EXISTS response
-func (d *Dialer) selectAndGetCount(folder string) (int, error) {
-	r, err := d.Exec("SELECT \""+AddSlashes.Replace(folder)+"\"", true, RetryCount, nil)
+// selectAndGetCount executes SELECT command and extracts message count from EXISTS response.
+func (d *Client) selectAndGetCount(ctx context.Context, folder string) (int, error) {
+	r, err := d.Exec(ctx, "SELECT \""+AddSlashes.Replace(folder)+"\"", true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return 0, err
 	}
@@ -96,8 +97,8 @@ func (d *Dialer) selectAndGetCount(folder string) (int, error) {
 
 // CreateFolder creates a new mailbox with the given name.
 // This command is not retried because CREATE is not idempotent.
-func (d *Dialer) CreateFolder(name string) error {
-	_, err := d.Exec(`CREATE "`+AddSlashes.Replace(name)+`"`, false, 0, nil)
+func (d *Client) CreateFolder(ctx context.Context, name string) error {
+	_, err := d.Exec(ctx, `CREATE "`+AddSlashes.Replace(name)+`"`, false, 0, nil)
 	if err != nil {
 		return fmt.Errorf("imap create folder: %w", err)
 	}
@@ -107,8 +108,8 @@ func (d *Dialer) CreateFolder(name string) error {
 // DeleteFolder permanently removes a mailbox.
 // If the deleted folder is currently selected, the folder state is cleared.
 // This command is not retried because DELETE is not idempotent.
-func (d *Dialer) DeleteFolder(name string) error {
-	_, err := d.Exec(`DELETE "`+AddSlashes.Replace(name)+`"`, false, 0, nil)
+func (d *Client) DeleteFolder(ctx context.Context, name string) error {
+	_, err := d.Exec(ctx, `DELETE "`+AddSlashes.Replace(name)+`"`, false, 0, nil)
 	if err != nil {
 		return fmt.Errorf("imap delete folder: %w", err)
 	}
@@ -122,8 +123,8 @@ func (d *Dialer) DeleteFolder(name string) error {
 // RenameFolder renames a mailbox from oldName to newName.
 // If the renamed folder is currently selected, the tracked folder name is updated.
 // This command is not retried because RENAME is not idempotent.
-func (d *Dialer) RenameFolder(oldName, newName string) error {
-	_, err := d.Exec(`RENAME "`+AddSlashes.Replace(oldName)+`" "`+AddSlashes.Replace(newName)+`"`, false, 0, nil)
+func (d *Client) RenameFolder(ctx context.Context, oldName, newName string) error {
+	_, err := d.Exec(ctx, `RENAME "`+AddSlashes.Replace(oldName)+`" "`+AddSlashes.Replace(newName)+`"`, false, 0, nil)
 	if err != nil {
 		return fmt.Errorf("imap rename folder: %w", err)
 	}
@@ -133,54 +134,54 @@ func (d *Dialer) RenameFolder(oldName, newName string) error {
 	return nil
 }
 
-// GetTotalEmailCount returns the total email count across all folders
-func (d *Dialer) GetTotalEmailCount() (count int, err error) {
-	return d.GetTotalEmailCountStartingFromExcluding("", nil)
+// GetTotalEmailCount returns the total email count across all folders.
+func (d *Client) GetTotalEmailCount(ctx context.Context) (count int, err error) {
+	return d.GetTotalEmailCountStartingFromExcluding(ctx, "", nil)
 }
 
-// GetTotalEmailCountExcluding returns total email count excluding specified folders
-func (d *Dialer) GetTotalEmailCountExcluding(excludedFolders []string) (count int, err error) {
-	return d.GetTotalEmailCountStartingFromExcluding("", excludedFolders)
+// GetTotalEmailCountExcluding returns total email count excluding specified folders.
+func (d *Client) GetTotalEmailCountExcluding(ctx context.Context, excludedFolders []string) (count int, err error) {
+	return d.GetTotalEmailCountStartingFromExcluding(ctx, "", excludedFolders)
 }
 
-// GetTotalEmailCountStartingFrom returns total email count starting from a specific folder
-func (d *Dialer) GetTotalEmailCountStartingFrom(startFolder string) (count int, err error) {
-	return d.GetTotalEmailCountStartingFromExcluding(startFolder, nil)
+// GetTotalEmailCountStartingFrom returns total email count starting from a specific folder.
+func (d *Client) GetTotalEmailCountStartingFrom(ctx context.Context, startFolder string) (count int, err error) {
+	return d.GetTotalEmailCountStartingFromExcluding(ctx, startFolder, nil)
 }
 
-// GetTotalEmailCountSafe returns total email count with error handling per folder
-func (d *Dialer) GetTotalEmailCountSafe() (count int, folderErrors []error, err error) {
-	return d.GetTotalEmailCountSafeStartingFromExcluding("", nil)
+// GetTotalEmailCountSafe returns total email count with error handling per folder.
+func (d *Client) GetTotalEmailCountSafe(ctx context.Context) (count int, folderErrors []error, err error) {
+	return d.GetTotalEmailCountSafeStartingFromExcluding(ctx, "", nil)
 }
 
-// GetTotalEmailCountSafeExcluding returns total email count excluding folders with error handling
-func (d *Dialer) GetTotalEmailCountSafeExcluding(excludedFolders []string) (count int, folderErrors []error, err error) {
-	return d.GetTotalEmailCountSafeStartingFromExcluding("", excludedFolders)
+// GetTotalEmailCountSafeExcluding returns total email count excluding folders with error handling.
+func (d *Client) GetTotalEmailCountSafeExcluding(ctx context.Context, excludedFolders []string) (count int, folderErrors []error, err error) {
+	return d.GetTotalEmailCountSafeStartingFromExcluding(ctx, "", excludedFolders)
 }
 
-// GetTotalEmailCountSafeStartingFrom returns total email count starting from folder with error handling
-func (d *Dialer) GetTotalEmailCountSafeStartingFrom(startFolder string) (count int, folderErrors []error, err error) {
-	return d.GetTotalEmailCountSafeStartingFromExcluding(startFolder, nil)
+// GetTotalEmailCountSafeStartingFrom returns total email count starting from folder with error handling.
+func (d *Client) GetTotalEmailCountSafeStartingFrom(ctx context.Context, startFolder string) (count int, folderErrors []error, err error) {
+	return d.GetTotalEmailCountSafeStartingFromExcluding(ctx, startFolder, nil)
 }
 
-// GetFolderStats returns statistics for all folders
-func (d *Dialer) GetFolderStats() ([]FolderStats, error) {
-	return d.GetFolderStatsStartingFromExcluding("", nil)
+// GetFolderStats returns statistics for all folders.
+func (d *Client) GetFolderStats(ctx context.Context) ([]FolderStats, error) {
+	return d.GetFolderStatsStartingFromExcluding(ctx, "", nil)
 }
 
-// GetFolderStatsExcluding returns statistics for folders excluding specified ones
-func (d *Dialer) GetFolderStatsExcluding(excludedFolders []string) ([]FolderStats, error) {
-	return d.GetFolderStatsStartingFromExcluding("", excludedFolders)
+// GetFolderStatsExcluding returns statistics for folders excluding specified ones.
+func (d *Client) GetFolderStatsExcluding(ctx context.Context, excludedFolders []string) ([]FolderStats, error) {
+	return d.GetFolderStatsStartingFromExcluding(ctx, "", excludedFolders)
 }
 
-// GetFolderStatsStartingFrom returns statistics for folders starting from a specific one
-func (d *Dialer) GetFolderStatsStartingFrom(startFolder string) ([]FolderStats, error) {
-	return d.GetFolderStatsStartingFromExcluding(startFolder, nil)
+// GetFolderStatsStartingFrom returns statistics for folders starting from a specific one.
+func (d *Client) GetFolderStatsStartingFrom(ctx context.Context, startFolder string) ([]FolderStats, error) {
+	return d.GetFolderStatsStartingFromExcluding(ctx, startFolder, nil)
 }
 
-// GetTotalEmailCountStartingFromExcluding returns total email count with options for starting folder and exclusions
-func (d *Dialer) GetTotalEmailCountStartingFromExcluding(startFolder string, excludedFolders []string) (count int, err error) {
-	folders, err := d.GetFolders()
+// GetTotalEmailCountStartingFromExcluding returns total email count with options for starting folder and exclusions.
+func (d *Client) GetTotalEmailCountStartingFromExcluding(ctx context.Context, startFolder string, excludedFolders []string) (count int, err error) {
+	folders, err := d.GetFolders(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -207,7 +208,7 @@ func (d *Dialer) GetTotalEmailCountStartingFromExcluding(startFolder string, exc
 			continue
 		}
 
-		folderCount, err := d.selectAndGetCount(folder)
+		folderCount, err := d.selectAndGetCount(ctx, folder)
 		if err == nil {
 			count += folderCount
 		}
@@ -216,18 +217,18 @@ func (d *Dialer) GetTotalEmailCountStartingFromExcluding(startFolder string, exc
 	// Restore original folder state
 	if currentFolder != "" {
 		if currentReadOnly {
-			_ = d.ExamineFolder(currentFolder)
+			_ = d.ExamineFolder(ctx, currentFolder)
 		} else {
-			_ = d.SelectFolder(currentFolder)
+			_ = d.SelectFolder(ctx, currentFolder)
 		}
 	}
 
 	return count, nil
 }
 
-// GetTotalEmailCountSafeStartingFromExcluding returns total email count with per-folder error handling
-func (d *Dialer) GetTotalEmailCountSafeStartingFromExcluding(startFolder string, excludedFolders []string) (count int, folderErrors []error, err error) {
-	folders, err := d.GetFolders()
+// GetTotalEmailCountSafeStartingFromExcluding returns total email count with per-folder error handling.
+func (d *Client) GetTotalEmailCountSafeStartingFromExcluding(ctx context.Context, startFolder string, excludedFolders []string) (count int, folderErrors []error, err error) {
+	folders, err := d.GetFolders(ctx)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -254,7 +255,7 @@ func (d *Dialer) GetTotalEmailCountSafeStartingFromExcluding(startFolder string,
 			continue
 		}
 
-		folderCount, folderErr := d.selectAndGetCount(folder)
+		folderCount, folderErr := d.selectAndGetCount(ctx, folder)
 		if folderErr != nil {
 			folderErrors = append(folderErrors, fmt.Errorf("folder %s: %w", folder, folderErr))
 			continue
@@ -265,18 +266,18 @@ func (d *Dialer) GetTotalEmailCountSafeStartingFromExcluding(startFolder string,
 	// Restore original folder state
 	if currentFolder != "" {
 		if currentReadOnly {
-			_ = d.ExamineFolder(currentFolder)
+			_ = d.ExamineFolder(ctx, currentFolder)
 		} else {
-			_ = d.SelectFolder(currentFolder)
+			_ = d.SelectFolder(ctx, currentFolder)
 		}
 	}
 
 	return count, folderErrors, nil
 }
 
-// GetFolderStatsStartingFromExcluding returns detailed statistics for folders with options
-func (d *Dialer) GetFolderStatsStartingFromExcluding(startFolder string, excludedFolders []string) ([]FolderStats, error) {
-	folders, err := d.GetFolders()
+// GetFolderStatsStartingFromExcluding returns detailed statistics for folders with options.
+func (d *Client) GetFolderStatsStartingFromExcluding(ctx context.Context, startFolder string, excludedFolders []string) ([]FolderStats, error) {
+	folders, err := d.GetFolders(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +309,7 @@ func (d *Dialer) GetFolderStatsStartingFromExcluding(startFolder string, exclude
 		stat := FolderStats{Name: folder}
 
 		// Get message count using helper function
-		count, err := d.selectAndGetCount(folder)
+		count, err := d.selectAndGetCount(ctx, folder)
 		if err != nil {
 			stat.Error = err
 			stats = append(stats, stat)
@@ -318,7 +319,7 @@ func (d *Dialer) GetFolderStatsStartingFromExcluding(startFolder string, exclude
 
 		// Get highest UID
 		if stat.Count > 0 {
-			uidResponse, err := d.Exec("UID SEARCH ALL", true, RetryCount, nil)
+			uidResponse, err := d.Exec(ctx, "UID SEARCH ALL", true, d.effectiveRetryCount(), nil)
 			if err == nil {
 				uids, err := parseUIDSearchResponse(uidResponse)
 				if err == nil && len(uids) > 0 {
@@ -333,9 +334,9 @@ func (d *Dialer) GetFolderStatsStartingFromExcluding(startFolder string, exclude
 	// Restore original folder state
 	if currentFolder != "" {
 		if currentReadOnly {
-			_ = d.ExamineFolder(currentFolder)
+			_ = d.ExamineFolder(ctx, currentFolder)
 		} else {
-			_ = d.SelectFolder(currentFolder)
+			_ = d.SelectFolder(ctx, currentFolder)
 		}
 	}
 

--- a/folder.go
+++ b/folder.go
@@ -12,7 +12,7 @@ import (
 type FolderStats struct {
 	Name   string
 	Count  int
-	MaxUID int
+	MaxUID UID
 	Error  error
 }
 

--- a/folder.go
+++ b/folder.go
@@ -54,7 +54,7 @@ func (d *Client) GetFolders(ctx context.Context) (folders []string, err error) {
 				}
 				i--
 			}
-			folders = append(folders, RemoveSlashes.Replace(string(line[i+1:end+1])))
+			folders = append(folders, removeSlashes.Replace(string(line[i+1:end+1])))
 		}
 		return err
 	})
@@ -67,7 +67,7 @@ func (d *Client) GetFolders(ctx context.Context) (folders []string, err error) {
 
 // ExamineFolder selects a folder in read-only mode.
 func (d *Client) ExamineFolder(ctx context.Context, folder string) error {
-	_, err := d.Exec(ctx, `EXAMINE "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
+	_, err := d.Exec(ctx, `EXAMINE "`+addSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (d *Client) ExamineFolder(ctx context.Context, folder string) error {
 
 // SelectFolder selects a folder in read-write mode.
 func (d *Client) SelectFolder(ctx context.Context, folder string) error {
-	_, err := d.Exec(ctx, `SELECT "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
+	_, err := d.Exec(ctx, `SELECT "`+addSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (d *Client) SelectFolder(ctx context.Context, folder string) error {
 
 // selectAndGetCount executes SELECT command and extracts message count from EXISTS response.
 func (d *Client) selectAndGetCount(ctx context.Context, folder string) (int, error) {
-	r, err := d.Exec(ctx, "SELECT \""+AddSlashes.Replace(folder)+"\"", true, d.effectiveRetryCount(), nil)
+	r, err := d.Exec(ctx, "SELECT \""+addSlashes.Replace(folder)+"\"", true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return 0, err
 	}
@@ -109,7 +109,7 @@ func (d *Client) selectAndGetCount(ctx context.Context, folder string) (int, err
 // CreateFolder creates a new mailbox with the given name.
 // This command is not retried because CREATE is not idempotent.
 func (d *Client) CreateFolder(ctx context.Context, name string) error {
-	_, err := d.Exec(ctx, `CREATE "`+AddSlashes.Replace(name)+`"`, false, 0, nil)
+	_, err := d.Exec(ctx, `CREATE "`+addSlashes.Replace(name)+`"`, false, 0, nil)
 	if err != nil {
 		return fmt.Errorf("imap create folder: %w", err)
 	}
@@ -120,7 +120,7 @@ func (d *Client) CreateFolder(ctx context.Context, name string) error {
 // If the deleted folder is currently selected, the folder state is cleared.
 // This command is not retried because DELETE is not idempotent.
 func (d *Client) DeleteFolder(ctx context.Context, name string) error {
-	_, err := d.Exec(ctx, `DELETE "`+AddSlashes.Replace(name)+`"`, false, 0, nil)
+	_, err := d.Exec(ctx, `DELETE "`+addSlashes.Replace(name)+`"`, false, 0, nil)
 	if err != nil {
 		return fmt.Errorf("imap delete folder: %w", err)
 	}
@@ -135,7 +135,7 @@ func (d *Client) DeleteFolder(ctx context.Context, name string) error {
 // If the renamed folder is currently selected, the tracked folder name is updated.
 // This command is not retried because RENAME is not idempotent.
 func (d *Client) RenameFolder(ctx context.Context, oldName, newName string) error {
-	_, err := d.Exec(ctx, `RENAME "`+AddSlashes.Replace(oldName)+`" "`+AddSlashes.Replace(newName)+`"`, false, 0, nil)
+	_, err := d.Exec(ctx, `RENAME "`+addSlashes.Replace(oldName)+`" "`+addSlashes.Replace(newName)+`"`, false, 0, nil)
 	if err != nil {
 		return fmt.Errorf("imap rename folder: %w", err)
 	}

--- a/folder_coverage_test.go
+++ b/folder_coverage_test.go
@@ -1,0 +1,323 @@
+package imap
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// folderStateHandler returns a mock handler that serves a LIST, SELECT, and
+// UID SEARCH ALL response backed by the given in-memory folder/UID table.
+// Folders absent from uidsByFolder exist but have zero messages.
+func folderStateHandler(folders []string, uidsByFolder map[string][]UID) func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+	return func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, tag+" LIST"):
+			var b strings.Builder
+			for _, f := range folders {
+				b.WriteString(`* LIST (\HasNoChildren) "/" "` + f + "\"\r\n")
+			}
+			b.WriteString(tag + " OK LIST completed\r\n")
+			w.WriteString(b.String())
+			return true
+		case strings.HasPrefix(upper, tag+" SELECT ") || strings.HasPrefix(upper, tag+" EXAMINE "):
+			// Parse folder out of quoted argument
+			folder := extractQuoted(line)
+			count := len(uidsByFolder[folder])
+			w.WriteString("* " + itoa(count) + " EXISTS\r\n")
+			w.WriteString("* 0 RECENT\r\n")
+			w.WriteString(tag + " OK [READ-WRITE] completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" UID SEARCH ALL"):
+			// Respond with the currently selected folder's UIDs. The mock
+			// does not track selection state, so inspect the last SELECT —
+			// tests that need this call one folder at a time.
+			folder := mockCurrentFolder(w)
+			parts := []string{"* SEARCH"}
+			for _, u := range uidsByFolder[folder] {
+				parts = append(parts, u.String())
+			}
+			w.WriteString(strings.Join(parts, " ") + "\r\n")
+			w.WriteString(tag + " OK SEARCH completed\r\n")
+			return true
+		}
+		return false
+	}
+}
+
+// extractQuoted returns the first "-quoted substring from line, or "" if none.
+func extractQuoted(line string) string {
+	a := strings.IndexByte(line, '"')
+	if a < 0 {
+		return ""
+	}
+	b := strings.IndexByte(line[a+1:], '"')
+	if b < 0 {
+		return ""
+	}
+	return line[a+1 : a+1+b]
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// mockCurrentFolder is a dummy that always returns "" — in practice tests
+// using folderStateHandler should override UID SEARCH explicitly when they
+// care about per-folder responses.
+func mockCurrentFolder(_ *bufio.Writer) string { return "" }
+
+func TestGetFolders(t *testing.T) {
+
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		if strings.HasPrefix(strings.ToUpper(line), tag+" LIST") {
+			w.WriteString(`* LIST (\HasNoChildren) "/" "INBOX"` + "\r\n")
+			w.WriteString(`* LIST (\HasNoChildren) "/" "Sent"` + "\r\n")
+			w.WriteString(`* LIST (\HasNoChildren) "/" "Drafts"` + "\r\n")
+			w.WriteString(tag + " OK LIST completed\r\n")
+			return true
+		}
+		return false
+	}
+
+	folders, err := d.GetFolders(context.Background())
+	if err != nil {
+		t.Fatalf("GetFolders: %v", err)
+	}
+	if len(folders) != 3 {
+		t.Fatalf("want 3 folders, got %d: %v", len(folders), folders)
+	}
+	want := map[string]bool{"INBOX": true, "Sent": true, "Drafts": true}
+	for _, f := range folders {
+		if !want[f] {
+			t.Errorf("unexpected folder %q", f)
+		}
+	}
+}
+
+func TestGetFoldersError(t *testing.T) {
+
+	d, srv := withMockClient(t)
+	srv.failCommands = map[string]bool{"LIST": true}
+	_, err := d.GetFolders(context.Background())
+	if err == nil {
+		t.Fatal("expected error when LIST fails")
+	}
+}
+
+func TestTotalEmailCount(t *testing.T) {
+
+	d, srv := withMockClient(t)
+
+	// Per-folder EXISTS counts.
+	counts := map[string]int{"INBOX": 5, "Sent": 2, "Drafts": 0}
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, tag+" LIST"):
+			w.WriteString(`* LIST (\HasNoChildren) "/" "INBOX"` + "\r\n")
+			w.WriteString(`* LIST (\HasNoChildren) "/" "Sent"` + "\r\n")
+			w.WriteString(`* LIST (\HasNoChildren) "/" "Drafts"` + "\r\n")
+			w.WriteString(tag + " OK LIST completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" SELECT ") || strings.HasPrefix(upper, tag+" EXAMINE "):
+			folder := extractQuoted(line)
+			c := counts[folder]
+			w.WriteString("* " + itoa(c) + " EXISTS\r\n* 0 RECENT\r\n")
+			w.WriteString(tag + " OK [READ-WRITE] completed\r\n")
+			return true
+		}
+		return false
+	}
+
+	total, fErrs, err := d.TotalEmailCount(context.Background(), CountOptions{})
+	if err != nil {
+		t.Fatalf("TotalEmailCount: %v", err)
+	}
+	if len(fErrs) != 0 {
+		t.Errorf("unexpected per-folder errors: %v", fErrs)
+	}
+	if total != 7 {
+		t.Errorf("want total 7, got %d", total)
+	}
+}
+
+func TestTotalEmailCountWithExcludeAndStart(t *testing.T) {
+
+	d, srv := withMockClient(t)
+	counts := map[string]int{"INBOX": 5, "Sent": 2, "Drafts": 4, "Trash": 3}
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, tag+" LIST"):
+			for _, f := range []string{"INBOX", "Sent", "Drafts", "Trash"} {
+				w.WriteString(`* LIST () "/" "` + f + "\"\r\n")
+			}
+			w.WriteString(tag + " OK LIST completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" SELECT ") || strings.HasPrefix(upper, tag+" EXAMINE "):
+			c := counts[extractQuoted(line)]
+			w.WriteString("* " + itoa(c) + " EXISTS\r\n* 0 RECENT\r\n")
+			w.WriteString(tag + " OK completed\r\n")
+			return true
+		}
+		return false
+	}
+
+	// Start at "Sent", exclude "Drafts". Counts Sent (2) and Trash (3) = 5.
+	total, _, err := d.TotalEmailCount(context.Background(), CountOptions{
+		StartFolder:    "Sent",
+		ExcludeFolders: []string{"Drafts"},
+	})
+	if err != nil {
+		t.Fatalf("TotalEmailCount: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("want 5, got %d", total)
+	}
+}
+
+func TestTotalEmailCountCtxCancel(t *testing.T) {
+
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		if strings.HasPrefix(strings.ToUpper(line), tag+" LIST") {
+			w.WriteString(`* LIST () "/" "INBOX"` + "\r\n")
+			w.WriteString(tag + " OK LIST completed\r\n")
+			return true
+		}
+		return false
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := d.TotalEmailCount(ctx, CountOptions{})
+	// LIST may or may not fail depending on race, but ctx should be honored.
+	if err != nil && !errors.Is(err, context.Canceled) {
+		// Some other errors can surface (e.g., closed conn); accept either.
+	}
+}
+
+func TestTotalEmailCountListError(t *testing.T) {
+
+	d, srv := withMockClient(t)
+	srv.failCommands = map[string]bool{"LIST": true}
+	_, _, err := d.TotalEmailCount(context.Background(), CountOptions{})
+	if err == nil {
+		t.Fatal("expected error when LIST fails")
+	}
+}
+
+func TestFolderStats(t *testing.T) {
+
+	d, srv := withMockClient(t)
+
+	// Keep which folder was last selected so UID SEARCH returns its UIDs.
+	var selected string
+	counts := map[string]int{"INBOX": 3, "Sent": 0}
+	uids := map[string][]UID{"INBOX": {10, 20, 30}, "Sent": {}}
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, tag+" LIST"):
+			for _, f := range []string{"INBOX", "Sent"} {
+				w.WriteString(`* LIST () "/" "` + f + "\"\r\n")
+			}
+			w.WriteString(tag + " OK LIST completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" SELECT ") || strings.HasPrefix(upper, tag+" EXAMINE "):
+			selected = extractQuoted(line)
+			w.WriteString("* " + itoa(counts[selected]) + " EXISTS\r\n* 0 RECENT\r\n")
+			w.WriteString(tag + " OK [READ-WRITE] completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" UID SEARCH ALL"):
+			parts := []string{"* SEARCH"}
+			for _, u := range uids[selected] {
+				parts = append(parts, u.String())
+			}
+			w.WriteString(strings.Join(parts, " ") + "\r\n")
+			w.WriteString(tag + " OK SEARCH completed\r\n")
+			return true
+		}
+		return false
+	}
+
+	stats, err := d.FolderStats(context.Background(), CountOptions{})
+	if err != nil {
+		t.Fatalf("FolderStats: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("want 2 stats, got %d", len(stats))
+	}
+	var inbox, sent FolderStat
+	for _, s := range stats {
+		switch s.Name {
+		case "INBOX":
+			inbox = s
+		case "Sent":
+			sent = s
+		}
+	}
+	if inbox.Count != 3 || inbox.MaxUID != 30 {
+		t.Errorf("INBOX: want count=3 maxUID=30, got %+v", inbox)
+	}
+	if sent.Count != 0 || sent.MaxUID != 0 {
+		t.Errorf("Sent: want count=0 maxUID=0, got %+v", sent)
+	}
+}
+
+func TestFolderStatsListError(t *testing.T) {
+
+	d, srv := withMockClient(t)
+	srv.failCommands = map[string]bool{"LIST": true}
+	_, err := d.FolderStats(context.Background(), CountOptions{})
+	if err == nil {
+		t.Fatal("expected error when LIST fails")
+	}
+}
+
+func TestRestoreSelection_Empty(t *testing.T) {
+
+	d, _ := withMockClient(t)
+	// No-op when folder is empty.
+	d.restoreSelection(context.Background(), "", false)
+}
+
+func TestRestoreSelection_ReadOnly(t *testing.T) {
+
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		if strings.HasPrefix(upper, tag+" EXAMINE ") || strings.HasPrefix(upper, tag+" SELECT ") {
+			w.WriteString("* 0 EXISTS\r\n* 0 RECENT\r\n")
+			w.WriteString(tag + " OK completed\r\n")
+			return true
+		}
+		return false
+	}
+	d.restoreSelection(context.Background(), "INBOX", true)
+	d.restoreSelection(context.Background(), "INBOX", false)
+}

--- a/folder_crud_test.go
+++ b/folder_crud_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+
 func setupTestDialer(t *testing.T) (*Dialer, *mockIMAPServer) {
 	t.Helper()
 
@@ -40,14 +41,14 @@ func TestCreateFolder(t *testing.T) {
 	d, _ := setupTestDialer(t)
 
 	t.Run("success", func(t *testing.T) {
-		err := d.CreateFolder("Archive")
+		err := d.CreateFolder(ctx, "Archive")
 		if err != nil {
 			t.Fatalf("CreateFolder failed: %v", err)
 		}
 	})
 
 	t.Run("special characters in name", func(t *testing.T) {
-		err := d.CreateFolder(`Folder "With" Quotes`)
+		err := d.CreateFolder(ctx, `Folder "With" Quotes`)
 		if err != nil {
 			t.Fatalf("CreateFolder with special chars failed: %v", err)
 		}
@@ -56,7 +57,7 @@ func TestCreateFolder(t *testing.T) {
 	t.Run("does not change current folder", func(t *testing.T) {
 		d.Folder = "INBOX"
 		d.ReadOnly = true
-		err := d.CreateFolder("NewFolder")
+		err := d.CreateFolder(ctx, "NewFolder")
 		if err != nil {
 			t.Fatalf("CreateFolder failed: %v", err)
 		}
@@ -73,7 +74,7 @@ func TestDeleteFolder(t *testing.T) {
 	d, _ := setupTestDialer(t)
 
 	t.Run("success", func(t *testing.T) {
-		err := d.DeleteFolder("Trash")
+		err := d.DeleteFolder(ctx, "Trash")
 		if err != nil {
 			t.Fatalf("DeleteFolder failed: %v", err)
 		}
@@ -83,7 +84,7 @@ func TestDeleteFolder(t *testing.T) {
 		d.Folder = "OldFolder"
 		d.ReadOnly = true
 
-		err := d.DeleteFolder("OldFolder")
+		err := d.DeleteFolder(ctx, "OldFolder")
 		if err != nil {
 			t.Fatalf("DeleteFolder failed: %v", err)
 		}
@@ -99,7 +100,7 @@ func TestDeleteFolder(t *testing.T) {
 		d.Folder = "INBOX"
 		d.ReadOnly = true
 
-		err := d.DeleteFolder("Trash")
+		err := d.DeleteFolder(ctx, "Trash")
 		if err != nil {
 			t.Fatalf("DeleteFolder failed: %v", err)
 		}
@@ -116,7 +117,7 @@ func TestRenameFolder(t *testing.T) {
 	d, _ := setupTestDialer(t)
 
 	t.Run("success", func(t *testing.T) {
-		err := d.RenameFolder("OldName", "NewName")
+		err := d.RenameFolder(ctx, "OldName", "NewName")
 		if err != nil {
 			t.Fatalf("RenameFolder failed: %v", err)
 		}
@@ -126,7 +127,7 @@ func TestRenameFolder(t *testing.T) {
 		d.Folder = "MyFolder"
 		d.ReadOnly = false
 
-		err := d.RenameFolder("MyFolder", "RenamedFolder")
+		err := d.RenameFolder(ctx, "MyFolder", "RenamedFolder")
 		if err != nil {
 			t.Fatalf("RenameFolder failed: %v", err)
 		}
@@ -138,7 +139,7 @@ func TestRenameFolder(t *testing.T) {
 	t.Run("does not update folder state when renaming other folder", func(t *testing.T) {
 		d.Folder = "INBOX"
 
-		err := d.RenameFolder("SomeFolder", "AnotherFolder")
+		err := d.RenameFolder(ctx, "SomeFolder", "AnotherFolder")
 		if err != nil {
 			t.Fatalf("RenameFolder failed: %v", err)
 		}
@@ -148,7 +149,7 @@ func TestRenameFolder(t *testing.T) {
 	})
 
 	t.Run("special characters", func(t *testing.T) {
-		err := d.RenameFolder(`Old "Name"`, `New "Name"`)
+		err := d.RenameFolder(ctx, `Old "Name"`, `New "Name"`)
 		if err != nil {
 			t.Fatalf("RenameFolder with special chars failed: %v", err)
 		}
@@ -162,7 +163,7 @@ func TestCopyEmail(t *testing.T) {
 		d.Folder = "INBOX"
 		d.ReadOnly = false
 
-		err := d.CopyEmail(123, "Archive")
+		err := d.CopyEmail(ctx, 123, "Archive")
 		if err != nil {
 			t.Fatalf("CopyEmail failed: %v", err)
 		}
@@ -172,7 +173,7 @@ func TestCopyEmail(t *testing.T) {
 		d.Folder = "INBOX"
 		d.ReadOnly = false
 
-		err := d.CopyEmail(456, "Sent")
+		err := d.CopyEmail(ctx, 456, "Sent")
 		if err != nil {
 			t.Fatalf("CopyEmail failed: %v", err)
 		}
@@ -185,7 +186,7 @@ func TestCopyEmail(t *testing.T) {
 		d.Folder = "INBOX"
 		d.ReadOnly = true
 
-		err := d.CopyEmail(789, "Archive")
+		err := d.CopyEmail(ctx, 789, "Archive")
 		if err != nil {
 			t.Fatalf("CopyEmail in read-only mode failed: %v", err)
 		}
@@ -200,7 +201,7 @@ func TestCopyEmail(t *testing.T) {
 func TestCreateFolder_Error(t *testing.T) {
 	d, server := setupTestDialer(t)
 	server.failCommands["CREATE"] = true
-	err := d.CreateFolder("BadFolder")
+	err := d.CreateFolder(ctx, "BadFolder")
 	if err == nil {
 		t.Fatal("expected error from CreateFolder")
 	}
@@ -212,7 +213,7 @@ func TestCreateFolder_Error(t *testing.T) {
 func TestDeleteFolder_Error(t *testing.T) {
 	d, server := setupTestDialer(t)
 	server.failCommands["DELETE"] = true
-	err := d.DeleteFolder("BadFolder")
+	err := d.DeleteFolder(ctx, "BadFolder")
 	if err == nil {
 		t.Fatal("expected error from DeleteFolder")
 	}
@@ -224,7 +225,7 @@ func TestDeleteFolder_Error(t *testing.T) {
 func TestRenameFolder_Error(t *testing.T) {
 	d, server := setupTestDialer(t)
 	server.failCommands["RENAME"] = true
-	err := d.RenameFolder("Old", "New")
+	err := d.RenameFolder(ctx, "Old", "New")
 	if err == nil {
 		t.Fatal("expected error from RenameFolder")
 	}
@@ -240,7 +241,7 @@ func TestCopyEmail_Error(t *testing.T) {
 	d.Folder = "INBOX"
 	d.ReadOnly = false
 
-	err := d.CopyEmail(123, "Archive")
+	err := d.CopyEmail(ctx, 123, "Archive")
 	if err == nil {
 		t.Fatal("expected error from CopyEmail when server rejects UID command")
 	}
@@ -255,7 +256,7 @@ func TestAppend(t *testing.T) {
 
 	t.Run("basic append", func(t *testing.T) {
 		msg := []byte("From: a@b.com\r\nTo: c@d.com\r\nSubject: Hi\r\n\r\nHello!")
-		err := d.Append("INBOX", nil, time.Time{}, msg)
+		err := d.Append(ctx, "INBOX", nil, time.Time{}, msg)
 		if err != nil {
 			t.Fatalf("Append failed: %v", err)
 		}
@@ -263,7 +264,7 @@ func TestAppend(t *testing.T) {
 
 	t.Run("append with flags", func(t *testing.T) {
 		msg := []byte("From: a@b.com\r\nTo: c@d.com\r\nSubject: Test\r\n\r\nBody")
-		err := d.Append("INBOX", []string{`\Seen`, `\Flagged`}, time.Time{}, msg)
+		err := d.Append(ctx, "INBOX", []string{`\Seen`, `\Flagged`}, time.Time{}, msg)
 		if err != nil {
 			t.Fatalf("Append with flags failed: %v", err)
 		}
@@ -272,14 +273,14 @@ func TestAppend(t *testing.T) {
 	t.Run("append with date", func(t *testing.T) {
 		msg := []byte("From: a@b.com\r\nTo: c@d.com\r\nSubject: Dated\r\n\r\nOld message")
 		date := time.Date(2024, time.January, 15, 10, 30, 0, 0, time.UTC)
-		err := d.Append("Drafts", []string{`\Draft`}, date, msg)
+		err := d.Append(ctx, "Drafts", []string{`\Draft`}, date, msg)
 		if err != nil {
 			t.Fatalf("Append with date failed: %v", err)
 		}
 	})
 
 	t.Run("append empty message", func(t *testing.T) {
-		err := d.Append("INBOX", nil, time.Time{}, []byte{})
+		err := d.Append(ctx, "INBOX", nil, time.Time{}, []byte{})
 		if err != nil {
 			t.Fatalf("Append empty message failed: %v", err)
 		}
@@ -287,7 +288,7 @@ func TestAppend(t *testing.T) {
 
 	t.Run("append special folder name", func(t *testing.T) {
 		msg := []byte("From: a@b.com\r\nSubject: test\r\n\r\nbody")
-		err := d.Append(`Folder "Special"`, nil, time.Time{}, msg)
+		err := d.Append(ctx, `Folder "Special"`, nil, time.Time{}, msg)
 		if err != nil {
 			t.Fatalf("Append to special folder failed: %v", err)
 		}

--- a/folder_test.go
+++ b/folder_test.go
@@ -1,12 +1,14 @@
 package imap
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 )
+
 
 // MockDialer for testing EXAMINE/SELECT redundancy
 type MockDialer struct {
@@ -59,7 +61,7 @@ func (m *MockDialer) Exec(command string, expectOK bool, retryCount int, handler
 	return "", fmt.Errorf("mock error: no response configured for command: %s", command)
 }
 
-func (m *MockDialer) ExamineFolder(folder string) error {
+func (m *MockDialer) ExamineFolder(_ context.Context, folder string) error {
 	_, err := m.Exec(`EXAMINE "`+AddSlashes.Replace(folder)+`"`, true, RetryCount, nil)
 	if err != nil {
 		return err
@@ -121,7 +123,7 @@ func TestExamineSelectRedundancy(t *testing.T) {
 			// This demonstrates why library methods use selectAndGetCount instead
 			for _, folder := range tt.folders {
 				// Anti-pattern: First calls ExamineFolder (gets folder info read-only)
-				err := mock.ExamineFolder(folder)
+				err := mock.ExamineFolder(ctx, folder)
 				if err != nil {
 					t.Errorf("ExamineFolder() error = %v", err)
 					continue

--- a/folder_test.go
+++ b/folder_test.go
@@ -62,7 +62,7 @@ func (m *MockDialer) Exec(command string, expectOK bool, retryCount int, handler
 }
 
 func (m *MockDialer) ExamineFolder(_ context.Context, folder string) error {
-	_, err := m.Exec(`EXAMINE "`+AddSlashes.Replace(folder)+`"`, true, RetryCount, nil)
+	_, err := m.Exec(`EXAMINE "`+addSlashes.Replace(folder)+`"`, true, RetryCount, nil)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (m *MockDialer) ExamineFolder(_ context.Context, folder string) error {
 }
 
 func (m *MockDialer) selectAndGetCount(folder string) (int, error) {
-	r, err := m.Exec("SELECT \""+AddSlashes.Replace(folder)+"\"", true, RetryCount, nil)
+	r, err := m.Exec("SELECT \""+addSlashes.Replace(folder)+"\"", true, RetryCount, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -131,7 +131,7 @@ func TestExamineSelectRedundancy(t *testing.T) {
 
 				// Anti-pattern: Then immediately calls SELECT (gets folder info + write access)
 				// This is redundant because SELECT provides everything EXAMINE does, plus write access
-				_, err = mock.Exec("SELECT \""+AddSlashes.Replace(folder)+"\"", true, RetryCount, nil)
+				_, err = mock.Exec("SELECT \""+addSlashes.Replace(folder)+"\"", true, RetryCount, nil)
 				if err != nil {
 					t.Errorf("SELECT error = %v", err)
 				}
@@ -153,8 +153,8 @@ func TestExamineSelectRedundancy(t *testing.T) {
 
 			// Verify that both EXAMINE and SELECT were called for each folder
 			for i, folder := range tt.folders {
-				examineCall := `EXAMINE "` + AddSlashes.Replace(folder) + `"`
-				selectCall := `SELECT "` + AddSlashes.Replace(folder) + `"`
+				examineCall := `EXAMINE "` + addSlashes.Replace(folder) + `"`
+				selectCall := `SELECT "` + addSlashes.Replace(folder) + `"`
 
 				if !contains(mock.execCalls[i*2], "EXAMINE") {
 					t.Errorf("Expected EXAMINE call for folder %s, got %s", folder, mock.execCalls[i*2])
@@ -205,7 +205,7 @@ func TestEfficientFolderAccess(t *testing.T) {
 			// ✅ EFFICIENT approach: Use only SELECT (what the library actually does)
 			// This is equivalent to calling selectAndGetCount() for each folder
 			for _, folder := range tt.folders {
-				_, err := mock.Exec("SELECT \""+AddSlashes.Replace(folder)+"\"", true, RetryCount, nil)
+				_, err := mock.Exec("SELECT \""+addSlashes.Replace(folder)+"\"", true, RetryCount, nil)
 				if err != nil {
 					t.Errorf("SELECT error = %v", err)
 				}
@@ -299,9 +299,9 @@ func TestSelectAndGetCount(t *testing.T) {
 			}
 
 			if tt.expectedError {
-				mock.errors["SELECT \""+AddSlashes.Replace(tt.folder)+"\""] = fmt.Errorf("folder not found: %s", tt.folder)
+				mock.errors["SELECT \""+addSlashes.Replace(tt.folder)+"\""] = fmt.Errorf("folder not found: %s", tt.folder)
 			} else {
-				mock.responses["SELECT \""+AddSlashes.Replace(tt.folder)+"\""] = tt.response
+				mock.responses["SELECT \""+addSlashes.Replace(tt.folder)+"\""] = tt.response
 			}
 
 			count, err := mock.selectAndGetCount(tt.folder)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.1
 
 require (
 	github.com/StirlingMarketingGroup/go-retry v0.0.0-20190512160921-94a8eb23e893
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/jhillyerd/enmime/v2 v2.3.0
 	github.com/rs/xid v1.6.0

--- a/idle.go
+++ b/idle.go
@@ -11,15 +11,37 @@ import (
 	"unicode"
 )
 
-// Connection state constants
+// State represents the connection state of a Client.
+type State int
+
+// Connection state constants.
 const (
-	StateDisconnected = iota
+	StateDisconnected State = iota
 	StateConnected
 	StateSelected
 	StateIdlePending
 	StateIdling
 	StateStoppingIdle
 )
+
+// String returns the human-readable name of the state.
+func (s State) String() string {
+	switch s {
+	case StateDisconnected:
+		return "Disconnected"
+	case StateConnected:
+		return "Connected"
+	case StateSelected:
+		return "Selected"
+	case StateIdlePending:
+		return "IdlePending"
+	case StateIdling:
+		return "Idling"
+	case StateStoppingIdle:
+		return "StoppingIdle"
+	}
+	return "Unknown"
+}
 
 // IDLE event type constants
 const (
@@ -227,7 +249,13 @@ func (d *Client) startIdleSingle(ctx context.Context, handler *IdleHandler) erro
 		<-d.idleStop
 		return ctx.Err()
 	case <-time.After(5 * time.Second):
-		d.setState(StateSelected)
+		// Server never sent "+ idling". Close the socket to unblock the
+		// detached Exec goroutine and wait for it to exit before returning;
+		// otherwise the goroutine leaks and the Client is left in an
+		// indeterminate IDLE state.
+		_ = d.Close()
+		d.setState(StateDisconnected)
+		<-d.idleStop
 		return fmt.Errorf("timeout waiting for + IDLE response")
 	}
 }
@@ -256,14 +284,14 @@ func (d *Client) StopIdle() error {
 }
 
 // setState sets the connection state with proper locking
-func (d *Client) setState(s int) {
+func (d *Client) setState(s State) {
 	d.stateMu.Lock()
 	defer d.stateMu.Unlock()
 	d.state = s
 }
 
 // State returns the current connection state with proper locking.
-func (d *Client) State() int {
+func (d *Client) State() State {
 	d.stateMu.Lock()
 	defer d.stateMu.Unlock()
 	return d.state

--- a/idle.go
+++ b/idle.go
@@ -167,6 +167,13 @@ func (d *Client) startIdleSingle(ctx context.Context, handler *IdleHandler) erro
 	d.idleDone = make(chan struct{})
 	idleReady := make(chan struct{})
 
+	// Detach the IDLE Exec from the caller's ctx. The outer monitor in
+	// StartIdle reacts to ctx cancellation by calling StopIdle, which sends
+	// DONE and lets the server reply with the tagged OK that ends Exec
+	// cleanly. Passing ctx directly into Exec would instead force a deadline
+	// past, close the socket, and leave the client disconnected.
+	execCtx := context.WithoutCancel(ctx)
+
 	go func() {
 		defer func() {
 			close(d.idleStop)
@@ -175,7 +182,7 @@ func (d *Client) startIdleSingle(ctx context.Context, handler *IdleHandler) erro
 			}
 		}()
 
-		_, err := d.Exec(ctx, "IDLE", true, 0, func(line []byte) error {
+		_, err := d.Exec(execCtx, "IDLE", true, 0, func(line []byte) error {
 			line = []byte(strings.ToUpper(string(line)))
 			switch {
 			case bytes.HasPrefix(line, []byte("+")):
@@ -211,6 +218,14 @@ func (d *Client) startIdleSingle(ctx context.Context, handler *IdleHandler) erro
 	select {
 	case <-idleReady:
 		return nil
+	case <-ctx.Done():
+		// Caller cancelled before the server's "+ idling" arrived. Close
+		// the socket to unblock the orphaned Exec goroutine (its execCtx
+		// is detached and will not observe cancellation on its own).
+		_ = d.Close()
+		d.setState(StateDisconnected)
+		<-d.idleStop
+		return ctx.Err()
 	case <-time.After(5 * time.Second):
 		d.setState(StateSelected)
 		return fmt.Errorf("timeout waiting for + IDLE response")

--- a/idle.go
+++ b/idle.go
@@ -24,7 +24,6 @@ const (
 	StateStoppingIdle
 )
 
-// String returns the human-readable name of the state.
 func (s State) String() string {
 	switch s {
 	case StateDisconnected:
@@ -249,10 +248,7 @@ func (d *Client) startIdleSingle(ctx context.Context, handler *IdleHandler) erro
 		<-d.idleStop
 		return ctx.Err()
 	case <-time.After(5 * time.Second):
-		// Server never sent "+ idling". Close the socket to unblock the
-		// detached Exec goroutine and wait for it to exit before returning;
-		// otherwise the goroutine leaks and the Client is left in an
-		// indeterminate IDLE state.
+		// Close to unblock the detached Exec goroutine; otherwise it leaks.
 		_ = d.Close()
 		d.setState(StateDisconnected)
 		<-d.idleStop

--- a/idle.go
+++ b/idle.go
@@ -28,21 +28,23 @@ const (
 	IdleEventFetch   = "FETCH"
 )
 
-// ExistsEvent represents an EXISTS event from IDLE
+// ExistsEvent represents an EXISTS event from IDLE.
+// SeqNum is the new total message count in the mailbox (RFC 3501 §7.3.1).
 type ExistsEvent struct {
-	MessageIndex int
+	SeqNum MessageSeq
 }
 
-// ExpungeEvent represents an EXPUNGE event from IDLE
+// ExpungeEvent represents an EXPUNGE event from IDLE.
+// SeqNum is the sequence number of the expunged message (RFC 3501 §7.4.1).
 type ExpungeEvent struct {
-	MessageIndex int
+	SeqNum MessageSeq
 }
 
-// FetchEvent represents a FETCH event from IDLE
+// FetchEvent represents a FETCH event from IDLE.
 type FetchEvent struct {
-	MessageIndex int
-	UID          uint32
-	Flags        []string
+	SeqNum MessageSeq
+	UID    UID
+	Flags  []string
 }
 
 // IdleHandler provides callbacks for IDLE events
@@ -52,39 +54,64 @@ type IdleHandler struct {
 	OnFetch   func(event FetchEvent)
 }
 
+// idleFetchUIDRE extracts the UID from an IDLE FETCH event payload.
+var idleFetchUIDRE = regexp.MustCompile(`(?i)\bUID\s+(\d+)`)
+
+// idleFetchFlagsRE extracts the FLAGS list from an IDLE FETCH event payload.
+var idleFetchFlagsRE = regexp.MustCompile(`(?i)FLAGS\s*\(([^)]*)\)`)
+
+// idleFetchHeadRE captures the leading "<seq> FETCH (" of an IDLE FETCH line.
+var idleFetchHeadRE = regexp.MustCompile(`(?i)^(\d+)\s+FETCH\s+\(`)
+
 // runIdleEvent processes an IDLE event and calls the appropriate handler
 func (d *Client) runIdleEvent(data []byte, handler *IdleHandler) error {
-	index := 0
-	event := ""
-	if _, err := fmt.Sscanf(string(data), "%d %s", &index, &event); err != nil {
+	str := string(data)
+	spaceIdx := strings.IndexByte(str, ' ')
+	if spaceIdx <= 0 {
 		return fmt.Errorf("invalid IDLE event format: %s", data)
 	}
+	seqStr := str[:spaceIdx]
+	seqNum, err := strconv.ParseUint(seqStr, 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid IDLE event format: %s", data)
+	}
+	rest := strings.TrimLeft(str[spaceIdx+1:], " \t")
+	event := rest
+	if i := strings.IndexAny(rest, " \t"); i != -1 {
+		event = rest[:i]
+	}
+	event = strings.ToUpper(strings.TrimRight(event, "\r\n"))
+
 	switch event {
 	case IdleEventExists:
 		if handler.OnExists != nil {
-			go handler.OnExists(ExistsEvent{MessageIndex: index})
+			go handler.OnExists(ExistsEvent{SeqNum: MessageSeq(seqNum)})
 		}
 	case IdleEventExpunge:
 		if handler.OnExpunge != nil {
-			go handler.OnExpunge(ExpungeEvent{MessageIndex: index})
+			go handler.OnExpunge(ExpungeEvent{SeqNum: MessageSeq(seqNum)})
 		}
 	case IdleEventFetch:
 		if handler.OnFetch == nil {
 			return nil
 		}
-		str := string(data)
-		re := regexp.MustCompile(`(?i)^(\d+)\s+FETCH\s+\(([^)]*FLAGS\s*\(([^)]*)\)[^)]*)`)
-		matches := re.FindStringSubmatch(str)
-		if len(matches) == 4 {
-			messageIndex, _ := strconv.Atoi(matches[1])
-			uid, _ := strconv.Atoi(matches[2])
-			flags := strings.FieldsFunc(strings.ReplaceAll(matches[3], `\`, ""), func(r rune) bool {
-				return unicode.IsSpace(r) || r == ','
-			})
-			go handler.OnFetch(FetchEvent{MessageIndex: messageIndex, UID: uint32(uid), Flags: flags})
-		} else {
+		if !idleFetchHeadRE.MatchString(str) {
 			return fmt.Errorf("invalid FETCH event format: %s", data)
 		}
+		flagsMatch := idleFetchFlagsRE.FindStringSubmatch(str)
+		if len(flagsMatch) != 2 {
+			return fmt.Errorf("invalid FETCH event format: %s", data)
+		}
+		flags := strings.FieldsFunc(strings.ReplaceAll(flagsMatch[1], `\`, ""), func(r rune) bool {
+			return unicode.IsSpace(r) || r == ','
+		})
+		var uid UID
+		if m := idleFetchUIDRE.FindStringSubmatch(str); len(m) == 2 {
+			if u, perr := strconv.ParseUint(m[1], 10, 32); perr == nil {
+				uid = UID(u)
+			}
+		}
+		go handler.OnFetch(FetchEvent{SeqNum: MessageSeq(seqNum), UID: uid, Flags: flags})
 	}
 
 	return nil

--- a/idle.go
+++ b/idle.go
@@ -2,6 +2,7 @@ package imap
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -52,7 +53,7 @@ type IdleHandler struct {
 }
 
 // runIdleEvent processes an IDLE event and calls the appropriate handler
-func (d *Dialer) runIdleEvent(data []byte, handler *IdleHandler) error {
+func (d *Client) runIdleEvent(data []byte, handler *IdleHandler) error {
 	index := 0
 	event := ""
 	if _, err := fmt.Sscanf(string(data), "%d %s", &index, &event); err != nil {
@@ -89,29 +90,33 @@ func (d *Dialer) runIdleEvent(data []byte, handler *IdleHandler) error {
 	return nil
 }
 
-// StartIdle starts IDLE monitoring with automatic reconnection and timeout handling
-func (d *Dialer) StartIdle(handler *IdleHandler) error {
+// StartIdle starts IDLE monitoring with automatic reconnection and timeout
+// handling. Cancelling ctx stops the background monitor and ends any active
+// IDLE session.
+func (d *Client) StartIdle(ctx context.Context, handler *IdleHandler) error {
 	go func() {
 		ticker := time.NewTicker(5 * time.Minute)
 		defer ticker.Stop()
 
 		for {
+			if err := ctx.Err(); err != nil {
+				return
+			}
 			if !d.Connected {
-				if err := d.Reconnect(); err != nil {
-					if Verbose {
-						warnLog(d.ConnNum, d.Folder, "IDLE reconnect failed", "error", err)
-					}
+				if err := d.Reconnect(ctx); err != nil {
+					warnLog(d.ConnNum, d.Folder, "IDLE reconnect failed", "error", err)
 					return
 				}
 			}
-			if err := d.startIdleSingle(handler); err != nil {
-				if Verbose {
-					warnLog(d.ConnNum, d.Folder, "IDLE session stopped", "error", err)
-				}
+			if err := d.startIdleSingle(ctx, handler); err != nil {
+				warnLog(d.ConnNum, d.Folder, "IDLE session stopped", "error", err)
 				return
 			}
 
 			select {
+			case <-ctx.Done():
+				_ = d.StopIdle()
+				return
 			case <-ticker.C:
 				_ = d.StopIdle()
 			case <-d.idleDone:
@@ -124,7 +129,7 @@ func (d *Dialer) StartIdle(handler *IdleHandler) error {
 }
 
 // startIdleSingle starts a single IDLE session
-func (d *Dialer) startIdleSingle(handler *IdleHandler) error {
+func (d *Client) startIdleSingle(ctx context.Context, handler *IdleHandler) error {
 	if d.State() == StateIdling || d.State() == StateIdlePending {
 		return fmt.Errorf("already entering or in IDLE")
 	}
@@ -143,7 +148,7 @@ func (d *Dialer) startIdleSingle(handler *IdleHandler) error {
 			}
 		}()
 
-		_, err := d.Exec("IDLE", true, 0, func(line []byte) error {
+		_, err := d.Exec(ctx, "IDLE", true, 0, func(line []byte) error {
 			line = []byte(strings.ToUpper(string(line)))
 			switch {
 			case bytes.HasPrefix(line, []byte("+")):
@@ -171,9 +176,7 @@ func (d *Dialer) startIdleSingle(handler *IdleHandler) error {
 			return nil
 		})
 		if err != nil {
-			if Verbose {
-				warnLog(d.ConnNum, d.Folder, "IDLE command error", "error", err)
-			}
+			warnLog(d.ConnNum, d.Folder, "IDLE command error", "error", err)
 			d.setState(StateDisconnected)
 		}
 	}()
@@ -187,15 +190,13 @@ func (d *Dialer) startIdleSingle(handler *IdleHandler) error {
 	}
 }
 
-// StopIdle stops the current IDLE session
-func (d *Dialer) StopIdle() error {
+// StopIdle stops the current IDLE session.
+func (d *Client) StopIdle() error {
 	if d.State() != StateIdling {
 		return fmt.Errorf("not in IDLE state")
 	}
 
-	if Verbose {
-		debugLog(d.ConnNum, d.Folder, "sending DONE to exit IDLE")
-	}
+	debugLog(d.ConnNum, d.Folder, "sending DONE to exit IDLE")
 	if _, err := d.conn.Write([]byte("DONE\r\n")); err != nil {
 		return fmt.Errorf("failed to send DONE: %v", err)
 	}
@@ -213,14 +214,14 @@ func (d *Dialer) StopIdle() error {
 }
 
 // setState sets the connection state with proper locking
-func (d *Dialer) setState(s int) {
+func (d *Client) setState(s int) {
 	d.stateMu.Lock()
 	defer d.stateMu.Unlock()
 	d.state = s
 }
 
-// State returns the current connection state with proper locking
-func (d *Dialer) State() int {
+// State returns the current connection state with proper locking.
+func (d *Client) State() int {
 	d.stateMu.Lock()
 	defer d.stateMu.Unlock()
 	return d.state

--- a/idle.go
+++ b/idle.go
@@ -256,21 +256,43 @@ func (d *Client) startIdleSingle(ctx context.Context, handler *IdleHandler) erro
 	}
 }
 
-// StopIdle stops the current IDLE session.
+// StopIdle stops the current IDLE session. Safe to call from multiple
+// goroutines; only the first caller that observes StateIdling performs the
+// DONE handshake, subsequent callers return an error without racing on the
+// shared idle channels.
 func (d *Client) StopIdle() error {
-	if d.State() != StateIdling {
+	if !d.casState(StateIdling, StateStoppingIdle) {
 		return fmt.Errorf("not in IDLE state")
 	}
+	idleDone := d.idleDone
+	idleStop := d.idleStop
 
 	debugLog(d.ConnNum, d.Folder, "sending DONE to exit IDLE")
 	if _, err := d.conn.Write([]byte("DONE\r\n")); err != nil {
+		// DONE write failed — connection is likely broken. Force-close so
+		// the Exec goroutine exits, then clean up the idle channels and
+		// drop state to Disconnected so the client isn't wedged in
+		// StateStoppingIdle.
+		_ = d.Close()
+		<-idleStop
+		d.idleDone, d.idleStop = nil, nil
+		d.setState(StateDisconnected)
 		return fmt.Errorf("failed to send DONE: %v", err)
 	}
 
-	d.setState(StateStoppingIdle)
-	close(d.idleDone)
+	close(idleDone)
 
-	<-d.idleStop
+	// Bound the wait so a stalled server can't hang the caller. 5 s is
+	// generous for a well-behaved server to reply to DONE; beyond that the
+	// server is either dead or malicious, so force-close the socket to
+	// unblock the Exec goroutine and move on.
+	select {
+	case <-idleStop:
+	case <-time.After(5 * time.Second):
+		_ = d.Close()
+		<-idleStop
+	}
+
 	d.idleDone, d.idleStop = nil, nil
 	if d.State() == StateStoppingIdle {
 		d.setState(StateSelected)
@@ -284,6 +306,19 @@ func (d *Client) setState(s State) {
 	d.stateMu.Lock()
 	defer d.stateMu.Unlock()
 	d.state = s
+}
+
+// casState atomically transitions state from `from` to `to`, returning true
+// if the swap was performed. Concurrent callers observing the same source
+// state cannot both succeed.
+func (d *Client) casState(from, to State) bool {
+	d.stateMu.Lock()
+	defer d.stateMu.Unlock()
+	if d.state != from {
+		return false
+	}
+	d.state = to
+	return true
 }
 
 // State returns the current connection state with proper locking.

--- a/idle_coverage_test.go
+++ b/idle_coverage_test.go
@@ -1,0 +1,229 @@
+package imap
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStateString(t *testing.T) {
+	cases := []struct {
+		s    State
+		want string
+	}{
+		{StateDisconnected, "Disconnected"},
+		{StateConnected, "Connected"},
+		{StateSelected, "Selected"},
+		{StateIdlePending, "IdlePending"},
+		{StateIdling, "Idling"},
+		{StateStoppingIdle, "StoppingIdle"},
+		{State(99), "Unknown"},
+	}
+	for _, c := range cases {
+		if got := c.s.String(); got != c.want {
+			t.Errorf("State(%d).String() = %q, want %q", c.s, got, c.want)
+		}
+	}
+}
+
+// idleMockHandler responds to SELECT and IDLE, synchronously consuming the
+// client's DONE so it doesn't fall through to the main server parser.
+func idleMockHandler(mu *sync.Mutex, idleActive *bool) func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+	return func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(strings.TrimSpace(line))
+		switch {
+		case strings.HasPrefix(upper, tag+" SELECT ") || strings.HasPrefix(upper, tag+" EXAMINE "):
+			w.WriteString("* 0 EXISTS\r\n* 0 RECENT\r\n")
+			w.WriteString(tag + " OK [READ-WRITE] completed\r\n")
+			return true
+		case strings.HasSuffix(upper, " IDLE"):
+			mu.Lock()
+			*idleActive = true
+			mu.Unlock()
+			w.WriteString("+ idling\r\n")
+			w.Flush()
+			// Block the server goroutine until the client sends DONE.
+			for {
+				doneLine, err := r.ReadString('\n')
+				if err != nil {
+					mu.Lock()
+					*idleActive = false
+					mu.Unlock()
+					return true
+				}
+				if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(doneLine)), "DONE") {
+					w.WriteString(tag + " OK IDLE completed\r\n")
+					w.Flush()
+					mu.Lock()
+					*idleActive = false
+					mu.Unlock()
+					return true
+				}
+			}
+		}
+		return false
+	}
+}
+
+func TestStartIdleAndStop(t *testing.T) {
+	d, srv := withMockClient(t)
+	var mu sync.Mutex
+	var idleActive bool
+	srv.handler = idleMockHandler(&mu, &idleActive)
+
+	if err := d.SelectFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("SelectFolder: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handler := &IdleHandler{
+		OnExists:  func(ExistsEvent) {},
+		OnExpunge: func(ExpungeEvent) {},
+		OnFetch:   func(FetchEvent) {},
+	}
+	if err := d.startIdleSingle(ctx, handler); err != nil {
+		t.Fatalf("startIdleSingle: %v", err)
+	}
+
+	// Wait for IDLE to be active.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		active := idleActive
+		mu.Unlock()
+		if active && d.State() == StateIdling {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if d.State() != StateIdling {
+		t.Fatalf("want StateIdling, got %v", d.State())
+	}
+
+	if err := d.StopIdle(); err != nil {
+		t.Fatalf("StopIdle: %v", err)
+	}
+
+	if d.State() == StateIdling {
+		t.Errorf("should no longer be Idling after StopIdle, got %v", d.State())
+	}
+}
+
+func TestStopIdleConcurrent(t *testing.T) {
+	d, srv := withMockClient(t)
+	var mu sync.Mutex
+	var idleActive bool
+	srv.handler = idleMockHandler(&mu, &idleActive)
+
+	if err := d.SelectFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("SelectFolder: %v", err)
+	}
+	if err := d.startIdleSingle(context.Background(), &IdleHandler{}); err != nil {
+		t.Fatalf("startIdleSingle: %v", err)
+	}
+
+	// Wait for IDLE to be active.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && d.State() != StateIdling {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if d.State() != StateIdling {
+		t.Fatalf("did not enter StateIdling")
+	}
+
+	// Fire concurrent StopIdles — exactly one should win, rest should
+	// return "not in IDLE state" without panicking on close-of-closed-channel.
+	const N = 8
+	errs := make(chan error, N)
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- d.StopIdle()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	var successes int
+	for err := range errs {
+		if err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Errorf("want exactly 1 successful StopIdle, got %d", successes)
+	}
+}
+
+func TestStopIdleBeforeStart(t *testing.T) {
+	d, _ := withMockClient(t)
+	d.setState(StateSelected)
+	if err := d.StopIdle(); err == nil {
+		t.Fatal("expected error when not idling")
+	}
+}
+
+func TestStartIdleAlreadyIdling(t *testing.T) {
+	d, _ := withMockClient(t)
+	d.setState(StateIdling)
+	if err := d.startIdleSingle(context.Background(), &IdleHandler{}); err == nil {
+		t.Fatal("expected error when already idling")
+	}
+}
+
+func TestStartIdlePublicWrapper(t *testing.T) {
+	d, srv := withMockClient(t)
+	var mu sync.Mutex
+	var idleActive bool
+	srv.handler = idleMockHandler(&mu, &idleActive)
+
+	if err := d.SelectFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("SelectFolder: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := d.StartIdle(ctx, &IdleHandler{}); err != nil {
+		t.Fatalf("StartIdle: %v", err)
+	}
+	// Give the background loop a moment to enter IDLE, then cancel.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if d.State() == StateIdling {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	// Wait for the monitor goroutine to react to ctx cancellation.
+	time.Sleep(200 * time.Millisecond)
+}
+
+func TestStartIdleTimeout(t *testing.T) {
+	d, srv := withMockClient(t)
+	// Handler that never responds with +, triggering the 5s timeout path.
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(strings.TrimSpace(line))
+		if strings.HasSuffix(upper, " IDLE") {
+			// Do not write anything — let the client hit its internal timeout.
+			return true
+		}
+		return false
+	}
+
+	// Shorten the test by using a ctx that cancels quickly, exercising the
+	// ctx.Done() branch rather than waiting 5s for the hard-coded timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := d.startIdleSingle(ctx, &IdleHandler{}); err == nil {
+		t.Fatal("expected startIdleSingle to fail when server never responds")
+	}
+}

--- a/idle_test.go
+++ b/idle_test.go
@@ -19,8 +19,8 @@ func TestRunIdleEvent_Exists(t *testing.T) {
 	}
 	select {
 	case e := <-ch:
-		if e.MessageIndex != 5 {
-			t.Errorf("expected MessageIndex 5, got %d", e.MessageIndex)
+		if e.SeqNum != 5 {
+			t.Errorf("expected SeqNum 5, got %d", e.SeqNum)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for EXISTS event")
@@ -40,8 +40,8 @@ func TestRunIdleEvent_Expunge(t *testing.T) {
 	}
 	select {
 	case e := <-ch:
-		if e.MessageIndex != 3 {
-			t.Errorf("expected MessageIndex 3, got %d", e.MessageIndex)
+		if e.SeqNum != 3 {
+			t.Errorf("expected SeqNum 3, got %d", e.SeqNum)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for EXPUNGE event")
@@ -56,16 +56,42 @@ func TestRunIdleEvent_Fetch(t *testing.T) {
 		OnFetch: func(event FetchEvent) { ch <- event },
 	}
 
-	if err := d.runIdleEvent([]byte(`7 FETCH (FLAGS (\Seen \Flagged))`), handler); err != nil {
+	if err := d.runIdleEvent([]byte(`7 FETCH (UID 9876 FLAGS (\Seen \Flagged))`), handler); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	select {
 	case e := <-ch:
-		if e.MessageIndex != 7 {
-			t.Errorf("expected MessageIndex 7, got %d", e.MessageIndex)
+		if e.SeqNum != 7 {
+			t.Errorf("expected SeqNum 7, got %d", e.SeqNum)
+		}
+		if e.UID != 9876 {
+			t.Errorf("expected UID 9876, got %d", e.UID)
 		}
 		if len(e.Flags) == 0 {
 			t.Error("expected non-empty flags")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for FETCH event")
+	}
+}
+
+// TestRunIdleEvent_FetchUIDAfterFlags covers the FLAGS-then-UID order some
+// servers emit, ensuring the UID is parsed regardless of attribute order.
+func TestRunIdleEvent_FetchUIDAfterFlags(t *testing.T) {
+	t.Parallel()
+	d := &Dialer{}
+	ch := make(chan FetchEvent, 1)
+	handler := &IdleHandler{
+		OnFetch: func(event FetchEvent) { ch <- event },
+	}
+
+	if err := d.runIdleEvent([]byte(`7 FETCH (FLAGS (\Seen) UID 4242)`), handler); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	select {
+	case e := <-ch:
+		if e.UID != 4242 {
+			t.Errorf("expected UID 4242, got %d", e.UID)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for FETCH event")

--- a/idle_test.go
+++ b/idle_test.go
@@ -183,7 +183,7 @@ func TestSetState_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func(state int) {
 			defer wg.Done()
-			d.setState(state % 6)
+			d.setState(State(state % 6))
 			_ = d.State()
 		}(i)
 	}

--- a/idle_test.go
+++ b/idle_test.go
@@ -181,11 +181,11 @@ func TestSetState_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
-		go func(state int) {
+		go func(s State) {
 			defer wg.Done()
-			d.setState(State(state % 6))
+			d.setState(s)
 			_ = d.State()
-		}(i)
+		}(State(i % 6))
 	}
 	wg.Wait()
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,6 +3,7 @@
 package imap
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 )
+
 
 // Integration tests require a running IMAP server.
 // Start one with: docker compose up -d
@@ -125,13 +127,13 @@ func TestIntegration_GetLastNUIDs(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Select INBOX
-	if err := conn.SelectFolder("INBOX"); err != nil {
+	if err := conn.SelectFolder(ctx, "INBOX"); err != nil {
 		t.Fatalf("Failed to select INBOX: %v", err)
 	}
 
 	// Test GetLastNUIDs
 	t.Run("GetLastNUIDs returns correct count", func(t *testing.T) {
-		uids, err := conn.GetLastNUIDs(5)
+		uids, err := conn.GetLastNUIDs(ctx, 5)
 		if err != nil {
 			t.Fatalf("GetLastNUIDs failed: %v", err)
 		}
@@ -150,7 +152,7 @@ func TestIntegration_GetLastNUIDs(t *testing.T) {
 	})
 
 	t.Run("GetLastNUIDs with n=0 returns nil", func(t *testing.T) {
-		uids, err := conn.GetLastNUIDs(0)
+		uids, err := conn.GetLastNUIDs(ctx, 0)
 		if err != nil {
 			t.Fatalf("GetLastNUIDs(0) failed: %v", err)
 		}
@@ -160,7 +162,7 @@ func TestIntegration_GetLastNUIDs(t *testing.T) {
 	})
 
 	t.Run("GetLastNUIDs with negative n returns nil", func(t *testing.T) {
-		uids, err := conn.GetLastNUIDs(-5)
+		uids, err := conn.GetLastNUIDs(ctx, -5)
 		if err != nil {
 			t.Fatalf("GetLastNUIDs(-5) failed: %v", err)
 		}
@@ -170,12 +172,12 @@ func TestIntegration_GetLastNUIDs(t *testing.T) {
 	})
 
 	t.Run("GetLastNUIDs with n greater than total returns all", func(t *testing.T) {
-		allUIDs, err := conn.GetUIDs("ALL")
+		allUIDs, err := conn.GetUIDs(ctx, "ALL")
 		if err != nil {
 			t.Fatalf("GetUIDs(ALL) failed: %v", err)
 		}
 
-		lastUIDs, err := conn.GetLastNUIDs(1000)
+		lastUIDs, err := conn.GetLastNUIDs(ctx, 1000)
 		if err != nil {
 			t.Fatalf("GetLastNUIDs(1000) failed: %v", err)
 		}
@@ -186,12 +188,12 @@ func TestIntegration_GetLastNUIDs(t *testing.T) {
 	})
 
 	t.Run("GetLastNUIDs returns highest UIDs", func(t *testing.T) {
-		allUIDs, err := conn.GetUIDs("ALL")
+		allUIDs, err := conn.GetUIDs(ctx, "ALL")
 		if err != nil {
 			t.Fatalf("GetUIDs(ALL) failed: %v", err)
 		}
 
-		last5, err := conn.GetLastNUIDs(5)
+		last5, err := conn.GetLastNUIDs(ctx, 5)
 		if err != nil {
 			t.Fatalf("GetLastNUIDs(5) failed: %v", err)
 		}
@@ -210,12 +212,12 @@ func TestIntegration_GetLastNUIDs(t *testing.T) {
 	t.Run("GetMaxUID returns highest UID", func(t *testing.T) {
 		t.Skip("enable once test-imap server supports RFC-4731. Currently fails with: 'Search command not supported'.")
 
-		last1, err := conn.GetLastNUIDs(1)
+		last1, err := conn.GetLastNUIDs(ctx, 1)
 		if err != nil {
 			t.Fatalf("GetLastNUIDs(1) failed: %v", err)
 		}
 
-		maxUID, err := conn.GetMaxUID()
+		maxUID, err := conn.GetMaxUID(ctx)
 		if err != nil {
 			t.Fatalf("GetMaxUID() failed: %v", err)
 		}
@@ -245,12 +247,12 @@ func TestIntegration_GetUIDs_Ranges(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	if err := conn.SelectFolder("INBOX"); err != nil {
+	if err := conn.SelectFolder(ctx, "INBOX"); err != nil {
 		t.Fatalf("Failed to select INBOX: %v", err)
 	}
 
 	t.Run("GetUIDs ALL returns all messages", func(t *testing.T) {
-		uids, err := conn.GetUIDs("ALL")
+		uids, err := conn.GetUIDs(ctx, "ALL")
 		if err != nil {
 			t.Fatalf("GetUIDs(ALL) failed: %v", err)
 		}
@@ -261,11 +263,11 @@ func TestIntegration_GetUIDs_Ranges(t *testing.T) {
 
 	t.Run("GetUIDs with * returns single highest UID", func(t *testing.T) {
 		// Re-select folder to ensure fresh state
-		if err := conn.SelectFolder("INBOX"); err != nil {
+		if err := conn.SelectFolder(ctx, "INBOX"); err != nil {
 			t.Fatalf("Failed to re-select INBOX: %v", err)
 		}
 
-		allUIDs, err := conn.GetUIDs("ALL")
+		allUIDs, err := conn.GetUIDs(ctx, "ALL")
 		if err != nil {
 			t.Fatalf("GetUIDs(ALL) failed: %v", err)
 		}
@@ -275,7 +277,7 @@ func TestIntegration_GetUIDs_Ranges(t *testing.T) {
 
 		// The * search should return the highest UID
 		// Note: GreenMail sometimes has issues with * searches, so we handle errors gracefully
-		starUIDs, err := conn.GetUIDs("*")
+		starUIDs, err := conn.GetUIDs(ctx, "*")
 		if err != nil {
 			t.Skipf("GetUIDs(*) failed (known GreenMail quirk): %v", err)
 		}
@@ -310,7 +312,7 @@ func TestIntegration_Connection(t *testing.T) {
 		}
 		defer conn.Close()
 
-		folders, err := conn.GetFolders()
+		folders, err := conn.GetFolders(ctx)
 		if err != nil {
 			t.Fatalf("Failed to get folders: %v", err)
 		}

--- a/message.go
+++ b/message.go
@@ -1,6 +1,7 @@
 package imap
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"mime"
@@ -150,8 +151,8 @@ func (a Attachment) String() string {
 //   - "SINCE 1-Jan-2024" - messages since a date
 //
 // Note: For retrieving the N most recent messages, use GetLastNUIDs instead.
-func (d *Dialer) GetUIDs(search string) (uids []int, err error) {
-	r, err := d.Exec(`UID SEARCH `+search, true, RetryCount, nil)
+func (d *Client) GetUIDs(ctx context.Context, search string) (uids []int, err error) {
+	r, err := d.Exec(ctx, `UID SEARCH `+search, true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -169,11 +170,11 @@ func (d *Dialer) GetUIDs(search string) (uids []int, err error) {
 //
 //	// Get the 10 most recent messages
 //	uids, err := conn.GetLastNUIDs(10)
-func (d *Dialer) GetLastNUIDs(n int) ([]int, error) {
+func (d *Client) GetLastNUIDs(ctx context.Context, n int) ([]int, error) {
 	if n <= 0 {
 		return nil, nil
 	}
-	allUIDs, err := d.GetUIDs("ALL")
+	allUIDs, err := d.GetUIDs(ctx, "ALL")
 	if err != nil {
 		return nil, err
 	}
@@ -187,24 +188,24 @@ func (d *Dialer) GetLastNUIDs(n int) ([]int, error) {
 //
 // The folder of interest must be already selected in either read-only mode,
 // ExamineFolder, or in read-write mode, SelectFolder.
-func (d *Dialer) GetMaxUID() (uid int, err error) {
-	r, err := d.Exec("UID SEARCH RETURN (MAX) 1:*", true, RetryCount, nil)
+func (d *Client) GetMaxUID(ctx context.Context) (uid int, err error) {
+	r, err := d.Exec(ctx, "UID SEARCH RETURN (MAX) 1:*", true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return 0, err
 	}
 	return parseMaxUIDSearchResponse(r)
 }
 
-// MoveEmail moves an email to a different folder
-func (d *Dialer) MoveEmail(uid int, folder string) (err error) {
+// MoveEmail moves an email to a different folder.
+func (d *Client) MoveEmail(ctx context.Context, uid int, folder string) (err error) {
 	// if we are currently read-only, switch to SELECT for the move-operation
 	readOnlyState := d.ReadOnly
 	if readOnlyState {
-		_ = d.SelectFolder(d.Folder)
+		_ = d.SelectFolder(ctx, d.Folder)
 	}
-	_, err = d.Exec(`UID MOVE `+strconv.Itoa(uid)+` "`+AddSlashes.Replace(folder)+`"`, true, RetryCount, nil)
+	_, err = d.Exec(ctx, `UID MOVE `+strconv.Itoa(uid)+` "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
 	if readOnlyState {
-		_ = d.ExamineFolder(d.Folder)
+		_ = d.ExamineFolder(ctx, d.Folder)
 	}
 	if err != nil {
 		return err
@@ -216,55 +217,55 @@ func (d *Dialer) MoveEmail(uid int, folder string) (err error) {
 // CopyEmail copies an email to a different folder.
 // Unlike MoveEmail, the original message remains in the current folder.
 // UID COPY is not retried because duplicating a message is not idempotent.
-func (d *Dialer) CopyEmail(uid int, folder string) error {
+func (d *Client) CopyEmail(ctx context.Context, uid int, folder string) error {
 	readOnlyState := d.ReadOnly
 	if readOnlyState {
-		if err := d.SelectFolder(d.Folder); err != nil {
+		if err := d.SelectFolder(ctx, d.Folder); err != nil {
 			return err
 		}
 	}
-	_, err := d.Exec(`UID COPY `+strconv.Itoa(uid)+` "`+AddSlashes.Replace(folder)+`"`, true, 0, nil)
+	_, err := d.Exec(ctx, `UID COPY `+strconv.Itoa(uid)+` "`+AddSlashes.Replace(folder)+`"`, true, 0, nil)
 	if readOnlyState {
-		if e := d.ExamineFolder(d.Folder); e != nil && err == nil {
+		if e := d.ExamineFolder(ctx, d.Folder); e != nil && err == nil {
 			err = e
 		}
 	}
 	return err
 }
 
-// MarkSeen marks an email as seen/read
-func (d *Dialer) MarkSeen(uid int) (err error) {
+// MarkSeen marks an email as seen/read.
+func (d *Client) MarkSeen(ctx context.Context, uid int) (err error) {
 	flags := Flags{
 		Seen: FlagAdd,
 	}
 
 	readOnlyState := d.ReadOnly
 	if readOnlyState {
-		_ = d.SelectFolder(d.Folder)
+		_ = d.SelectFolder(ctx, d.Folder)
 	}
-	err = d.SetFlags(uid, flags)
+	err = d.SetFlags(ctx, uid, flags)
 	if readOnlyState {
-		_ = d.ExamineFolder(d.Folder)
+		_ = d.ExamineFolder(ctx, d.Folder)
 	}
 
 	return err
 }
 
-// DeleteEmail marks an email for deletion
-func (d *Dialer) DeleteEmail(uid int) (err error) {
+// DeleteEmail marks an email for deletion.
+func (d *Client) DeleteEmail(ctx context.Context, uid int) (err error) {
 	flags := Flags{
 		Deleted: FlagAdd,
 	}
 
 	readOnlyState := d.ReadOnly
 	if readOnlyState {
-		if err = d.SelectFolder(d.Folder); err != nil {
+		if err = d.SelectFolder(ctx, d.Folder); err != nil {
 			return err
 		}
 	}
-	err = d.SetFlags(uid, flags)
+	err = d.SetFlags(ctx, uid, flags)
 	if readOnlyState {
-		if e := d.ExamineFolder(d.Folder); e != nil && err == nil {
+		if e := d.ExamineFolder(ctx, d.Folder); e != nil && err == nil {
 			err = e
 		}
 	}
@@ -272,25 +273,25 @@ func (d *Dialer) DeleteEmail(uid int) (err error) {
 	return err
 }
 
-// Expunge permanently removes emails marked for deletion
-func (d *Dialer) Expunge() (err error) {
+// Expunge permanently removes emails marked for deletion.
+func (d *Client) Expunge(ctx context.Context) (err error) {
 	readOnlyState := d.ReadOnly
 	if readOnlyState {
-		if err = d.SelectFolder(d.Folder); err != nil {
+		if err = d.SelectFolder(ctx, d.Folder); err != nil {
 			return err
 		}
 	}
-	_, err = d.Exec("EXPUNGE", false, RetryCount, nil)
+	_, err = d.Exec(ctx, "EXPUNGE", false, d.effectiveRetryCount(), nil)
 	if readOnlyState {
-		if e := d.ExamineFolder(d.Folder); e != nil && err == nil {
+		if e := d.ExamineFolder(ctx, d.Folder); e != nil && err == nil {
 			err = e
 		}
 	}
 	return err
 }
 
-// SetFlags sets message flags (seen, deleted, etc.)
-func (d *Dialer) SetFlags(uid int, flags Flags) (err error) {
+// SetFlags sets message flags (seen, deleted, etc.).
+func (d *Client) SetFlags(ctx context.Context, uid int, flags Flags) (err error) {
 	// craft the flags-string
 	addFlags := []string{}
 	removeFlags := []string{}
@@ -332,11 +333,11 @@ func (d *Dialer) SetFlags(uid int, flags Flags) (err error) {
 	// if we are currently read-only, switch to SELECT for the move-operation
 	readOnlyState := d.ReadOnly
 	if readOnlyState {
-		_ = d.SelectFolder(d.Folder)
+		_ = d.SelectFolder(ctx, d.Folder)
 	}
-	_, err = d.Exec(query, true, RetryCount, nil)
+	_, err = d.Exec(ctx, query, true, d.effectiveRetryCount(), nil)
 	if readOnlyState {
-		_ = d.ExamineFolder(d.Folder)
+		_ = d.ExamineFolder(ctx, d.Folder)
 	}
 
 	return err
@@ -344,7 +345,7 @@ func (d *Dialer) SetFlags(uid int, flags Flags) (err error) {
 
 // parseEmailBody parses an RFC 2822 message body string and populates the Email fields.
 // Returns true if parsing succeeded.
-func (d *Dialer) parseEmailBody(e *Email, bodyStr string) bool {
+func (d *Client) parseEmailBody(e *Email, bodyStr string) bool {
 	r := strings.NewReader(bodyStr)
 	env, err := enmime.ReadEnvelope(r)
 	if err != nil {
@@ -404,7 +405,7 @@ func unwrapTokens(tks []*Token) []*Token {
 
 // parseEmailRecord processes a single FETCH record for GetEmails, returning the
 // parsed email, whether parsing succeeded, and any error.
-func (d *Dialer) parseEmailRecord(tks []*Token) (*Email, bool, error) {
+func (d *Client) parseEmailRecord(tks []*Token) (*Email, bool, error) {
 	tks = unwrapTokens(tks)
 	e := &Email{}
 	skip := 0
@@ -437,9 +438,9 @@ func (d *Dialer) parseEmailRecord(tks []*Token) (*Email, bool, error) {
 	return e, success, nil
 }
 
-// GetEmails retrieves full email messages including body content
-func (d *Dialer) GetEmails(uids ...int) (emails map[int]*Email, err error) {
-	emails, err = d.GetOverviews(uids...)
+// GetEmails retrieves full email messages including body content.
+func (d *Client) GetEmails(ctx context.Context, uids ...int) (emails map[int]*Email, err error) {
+	emails, err = d.GetOverviews(ctx, uids...)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +469,7 @@ func (d *Dialer) GetEmails(uids ...int) (emails map[int]*Email, err error) {
 
 	var records [][]*Token
 	err = retry.Retry(func() (err error) {
-		r, err := d.Exec("UID FETCH "+uidsStr.String()+" BODY.PEEK[]", true, 0, nil)
+		r, err := d.Exec(ctx, "UID FETCH "+uidsStr.String()+" BODY.PEEK[]", true, 0, nil)
 		if err != nil {
 			return err
 		}
@@ -501,19 +502,19 @@ func (d *Dialer) GetEmails(uids ...int) (emails map[int]*Email, err error) {
 			}
 		}
 		return err
-	}, RetryCount, func(err error) error {
+	}, d.effectiveRetryCount(), func(err error) error {
 		errorLog(d.ConnNum, d.Folder, "fetch failed", "error", err)
 		_ = d.Close()
 		return nil
 	}, func() error {
-		return d.Reconnect()
+		return d.Reconnect(ctx)
 	})
 
 	return emails, err
 }
 
 // parseEnvelope extracts envelope data (date, subject, addresses, message-id) from an ENVELOPE token.
-func (d *Dialer) parseEnvelope(e *Email, envelopeToken *Token, tks []*Token) error {
+func (d *Client) parseEnvelope(e *Email, envelopeToken *Token, tks []*Token) error {
 	charsetReader := func(label string, input io.Reader) (io.Reader, error) {
 		label = strings.ReplaceAll(label, "windows-", "cp")
 		encoding, _ := charset.Lookup(label)
@@ -561,7 +562,7 @@ func (d *Dialer) parseEnvelope(e *Email, envelopeToken *Token, tks []*Token) err
 }
 
 // parseEnvelopeAddresses parses a single address-list field from an ENVELOPE token.
-func (d *Dialer) parseEnvelopeAddresses(dest *EmailAddresses, addrToken *Token, dec *mime.WordDecoder, tks []*Token, debug string) error {
+func (d *Client) parseEnvelopeAddresses(dest *EmailAddresses, addrToken *Token, dec *mime.WordDecoder, tks []*Token, debug string) error {
 	if addrToken.Type == TNil {
 		return nil
 	}
@@ -599,7 +600,7 @@ func (d *Dialer) parseEnvelopeAddresses(dest *EmailAddresses, addrToken *Token, 
 
 // parseOverviewField processes a single field (FLAGS, INTERNALDATE, RFC822.SIZE, ENVELOPE, UID)
 // in an overview record at position i, returning the number of extra tokens to skip.
-func (d *Dialer) parseOverviewField(e *Email, tks []*Token, i int, fieldName string) (skip int, err error) {
+func (d *Client) parseOverviewField(e *Email, tks []*Token, i int, fieldName string) (skip int, err error) {
 	switch fieldName {
 	case "FLAGS":
 		if err = d.CheckType(tks[i+1], []TType{TContainer}, tks, "after FLAGS"); err != nil {
@@ -645,7 +646,7 @@ func (d *Dialer) parseOverviewField(e *Email, tks []*Token, i int, fieldName str
 }
 
 // parseOverviewRecord processes a single FETCH record's tokens into an Email.
-func (d *Dialer) parseOverviewRecord(tks []*Token) (*Email, error) {
+func (d *Client) parseOverviewRecord(tks []*Token) (*Email, error) {
 	tks = unwrapTokens(tks)
 	e := &Email{}
 	skip := 0
@@ -666,8 +667,8 @@ func (d *Dialer) parseOverviewRecord(tks []*Token) (*Email, error) {
 	return e, nil
 }
 
-// GetOverviews retrieves email overview information (headers, flags, etc.)
-func (d *Dialer) GetOverviews(uids ...int) (emails map[int]*Email, err error) {
+// GetOverviews retrieves email overview information (headers, flags, etc.).
+func (d *Client) GetOverviews(ctx context.Context, uids ...int) (emails map[int]*Email, err error) {
 	uidsStr := strings.Builder{}
 	if len(uids) == 0 {
 		uidsStr.WriteString("1:*")
@@ -686,7 +687,7 @@ func (d *Dialer) GetOverviews(uids ...int) (emails map[int]*Email, err error) {
 
 	var records [][]*Token
 	err = retry.Retry(func() (err error) {
-		r, err := d.Exec("UID FETCH "+uidsStr.String()+" ALL", true, 0, nil)
+		r, err := d.Exec(ctx, "UID FETCH "+uidsStr.String()+" ALL", true, 0, nil)
 		if err != nil {
 			return err
 		}
@@ -700,12 +701,12 @@ func (d *Dialer) GetOverviews(uids ...int) (emails map[int]*Email, err error) {
 			return err
 		}
 		return err
-	}, RetryCount, func(err error) error {
+	}, d.effectiveRetryCount(), func(err error) error {
 		errorLog(d.ConnNum, d.Folder, "fetch failed", "error", err)
 		_ = d.Close()
 		return nil
 	}, func() error {
-		return d.Reconnect()
+		return d.Reconnect(ctx)
 	})
 	if err != nil {
 		return nil, err

--- a/message.go
+++ b/message.go
@@ -390,7 +390,7 @@ func (d *Client) parseEmailBody(e *Email, bodyStr string) bool {
 	if err != nil {
 		if Verbose {
 			warnLog(d.ConnNum, d.Folder, "email body could not be parsed",
-				"error", err, "envelope", fmt.Sprintf("%+v", env), "body", bodyStr)
+				"error", err, "body", bodyStr)
 		}
 		return false
 	}

--- a/message.go
+++ b/message.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"reflect"
 	"strconv"
@@ -17,6 +18,34 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
+// uidFromToken validates and converts a parsed TNumber into a UID, rejecting
+// values outside RFC 3501's 32-bit unsigned range so a malformed server
+// response cannot silently wrap.
+func uidFromToken(n int64) (UID, error) {
+	if n < 0 || n > math.MaxUint32 {
+		return 0, fmt.Errorf("UID %d out of 32-bit range", n)
+	}
+	return UID(n), nil
+}
+
+// UID is an IMAP unique identifier (RFC 3501 §2.3.1.1). UIDs are 32-bit
+// unsigned integers scoped to a mailbox + UIDVALIDITY value.
+type UID uint32
+
+// MessageSeq is an IMAP message sequence number (RFC 3501 §2.3.1.2). Sequence
+// numbers are 1-based positions within the currently selected mailbox and
+// change as messages are added or expunged — prefer UIDs for durable
+// references. Zero is not a valid sequence number.
+type MessageSeq uint32
+
+// String returns the UID formatted as a decimal string, suitable for
+// embedding in IMAP command arguments.
+func (u UID) String() string { return strconv.FormatUint(uint64(u), 10) }
+
+// String returns the sequence number formatted as a decimal string, suitable
+// for embedding in IMAP command arguments.
+func (s MessageSeq) String() string { return strconv.FormatUint(uint64(s), 10) }
+
 // EmailAddresses represents a map of email addresses to display names
 type EmailAddresses map[string]string
 
@@ -27,7 +56,7 @@ type Email struct {
 	Sent        time.Time
 	Size        uint64
 	Subject     string
-	UID         int
+	UID         UID
 	MessageID   string
 	From        EmailAddresses
 	To          EmailAddresses
@@ -151,7 +180,7 @@ func (a Attachment) String() string {
 //   - "SINCE 1-Jan-2024" - messages since a date
 //
 // Note: For retrieving the N most recent messages, use GetLastNUIDs instead.
-func (d *Client) GetUIDs(ctx context.Context, search string) (uids []int, err error) {
+func (d *Client) GetUIDs(ctx context.Context, search string) (uids []UID, err error) {
 	r, err := d.Exec(ctx, `UID SEARCH `+search, true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return nil, err
@@ -170,7 +199,7 @@ func (d *Client) GetUIDs(ctx context.Context, search string) (uids []int, err er
 //
 //	// Get the 10 most recent messages
 //	uids, err := conn.GetLastNUIDs(10)
-func (d *Client) GetLastNUIDs(ctx context.Context, n int) ([]int, error) {
+func (d *Client) GetLastNUIDs(ctx context.Context, n int) ([]UID, error) {
 	if n <= 0 {
 		return nil, nil
 	}
@@ -188,7 +217,7 @@ func (d *Client) GetLastNUIDs(ctx context.Context, n int) ([]int, error) {
 //
 // The folder of interest must be already selected in either read-only mode,
 // ExamineFolder, or in read-write mode, SelectFolder.
-func (d *Client) GetMaxUID(ctx context.Context) (uid int, err error) {
+func (d *Client) GetMaxUID(ctx context.Context) (uid UID, err error) {
 	r, err := d.Exec(ctx, "UID SEARCH RETURN (MAX) 1:*", true, d.effectiveRetryCount(), nil)
 	if err != nil {
 		return 0, err
@@ -197,13 +226,13 @@ func (d *Client) GetMaxUID(ctx context.Context) (uid int, err error) {
 }
 
 // MoveEmail moves an email to a different folder.
-func (d *Client) MoveEmail(ctx context.Context, uid int, folder string) (err error) {
+func (d *Client) MoveEmail(ctx context.Context, uid UID, folder string) (err error) {
 	// if we are currently read-only, switch to SELECT for the move-operation
 	readOnlyState := d.ReadOnly
 	if readOnlyState {
 		_ = d.SelectFolder(ctx, d.Folder)
 	}
-	_, err = d.Exec(ctx, `UID MOVE `+strconv.Itoa(uid)+` "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
+	_, err = d.Exec(ctx, `UID MOVE `+uid.String()+` "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
 	if readOnlyState {
 		_ = d.ExamineFolder(ctx, d.Folder)
 	}
@@ -217,14 +246,14 @@ func (d *Client) MoveEmail(ctx context.Context, uid int, folder string) (err err
 // CopyEmail copies an email to a different folder.
 // Unlike MoveEmail, the original message remains in the current folder.
 // UID COPY is not retried because duplicating a message is not idempotent.
-func (d *Client) CopyEmail(ctx context.Context, uid int, folder string) error {
+func (d *Client) CopyEmail(ctx context.Context, uid UID, folder string) error {
 	readOnlyState := d.ReadOnly
 	if readOnlyState {
 		if err := d.SelectFolder(ctx, d.Folder); err != nil {
 			return err
 		}
 	}
-	_, err := d.Exec(ctx, `UID COPY `+strconv.Itoa(uid)+` "`+AddSlashes.Replace(folder)+`"`, true, 0, nil)
+	_, err := d.Exec(ctx, `UID COPY `+uid.String()+` "`+AddSlashes.Replace(folder)+`"`, true, 0, nil)
 	if readOnlyState {
 		if e := d.ExamineFolder(ctx, d.Folder); e != nil && err == nil {
 			err = e
@@ -234,7 +263,7 @@ func (d *Client) CopyEmail(ctx context.Context, uid int, folder string) error {
 }
 
 // MarkSeen marks an email as seen/read.
-func (d *Client) MarkSeen(ctx context.Context, uid int) (err error) {
+func (d *Client) MarkSeen(ctx context.Context, uid UID) (err error) {
 	flags := Flags{
 		Seen: FlagAdd,
 	}
@@ -252,7 +281,7 @@ func (d *Client) MarkSeen(ctx context.Context, uid int) (err error) {
 }
 
 // DeleteEmail marks an email for deletion.
-func (d *Client) DeleteEmail(ctx context.Context, uid int) (err error) {
+func (d *Client) DeleteEmail(ctx context.Context, uid UID) (err error) {
 	flags := Flags{
 		Deleted: FlagAdd,
 	}
@@ -291,7 +320,7 @@ func (d *Client) Expunge(ctx context.Context) (err error) {
 }
 
 // SetFlags sets message flags (seen, deleted, etc.).
-func (d *Client) SetFlags(ctx context.Context, uid int, flags Flags) (err error) {
+func (d *Client) SetFlags(ctx context.Context, uid UID, flags Flags) (err error) {
 	// craft the flags-string
 	addFlags := []string{}
 	removeFlags := []string{}
@@ -431,7 +460,11 @@ func (d *Client) parseEmailRecord(tks []*Token) (*Email, bool, error) {
 			if err := d.CheckType(tks[i+1], []TType{TNumber}, tks, "after UID"); err != nil {
 				return nil, false, err
 			}
-			e.UID = tks[i+1].Num
+			u, err := uidFromToken(tks[i+1].Num)
+			if err != nil {
+				return nil, false, err
+			}
+			e.UID = u
 			skip++
 		}
 	}
@@ -439,7 +472,7 @@ func (d *Client) parseEmailRecord(tks []*Token) (*Email, bool, error) {
 }
 
 // GetEmails retrieves full email messages including body content.
-func (d *Client) GetEmails(ctx context.Context, uids ...int) (emails map[int]*Email, err error) {
+func (d *Client) GetEmails(ctx context.Context, uids ...UID) (emails map[UID]*Email, err error) {
 	emails, err = d.GetOverviews(ctx, uids...)
 	if err != nil {
 		return nil, err
@@ -462,7 +495,7 @@ func (d *Client) GetEmails(ctx context.Context, uids ...int) (emails map[int]*Em
 			if i != 0 {
 				uidsStr.WriteByte(',')
 			}
-			uidsStr.WriteString(strconv.Itoa(u))
+			uidsStr.WriteString(u.String())
 			i++
 		}
 	}
@@ -639,7 +672,11 @@ func (d *Client) parseOverviewField(e *Email, tks []*Token, i int, fieldName str
 		if err = d.CheckType(tks[i+1], []TType{TNumber}, tks, "after UID"); err != nil {
 			return 0, err
 		}
-		e.UID = tks[i+1].Num
+		u, err := uidFromToken(tks[i+1].Num)
+		if err != nil {
+			return 0, err
+		}
+		e.UID = u
 		return 1, nil
 	}
 	return 0, nil
@@ -668,7 +705,7 @@ func (d *Client) parseOverviewRecord(tks []*Token) (*Email, error) {
 }
 
 // GetOverviews retrieves email overview information (headers, flags, etc.).
-func (d *Client) GetOverviews(ctx context.Context, uids ...int) (emails map[int]*Email, err error) {
+func (d *Client) GetOverviews(ctx context.Context, uids ...UID) (emails map[UID]*Email, err error) {
 	uidsStr := strings.Builder{}
 	if len(uids) == 0 {
 		uidsStr.WriteString("1:*")
@@ -681,7 +718,7 @@ func (d *Client) GetOverviews(ctx context.Context, uids ...int) (emails map[int]
 			if i != 0 {
 				uidsStr.WriteByte(',')
 			}
-			uidsStr.WriteString(strconv.Itoa(u))
+			uidsStr.WriteString(u.String())
 		}
 	}
 
@@ -712,7 +749,7 @@ func (d *Client) GetOverviews(ctx context.Context, uids ...int) (emails map[int]
 		return nil, err
 	}
 
-	emails = make(map[int]*Email, len(uids))
+	emails = make(map[UID]*Email, len(uids))
 
 	for _, tks := range records {
 		e, err := d.parseOverviewRecord(tks)

--- a/message.go
+++ b/message.go
@@ -513,8 +513,14 @@ func (d *Client) GetEmails(ctx context.Context, uids ...UID) (emails map[UID]*Em
 
 	var records [][]*Token
 	err = retry.Retry(func() (err error) {
+		if cerr := ctx.Err(); cerr != nil {
+			return &retry.PermFail{Err: cerr}
+		}
 		r, err := d.Exec(ctx, "UID FETCH "+uidsStr.String()+" BODY.PEEK[]", true, 0, nil)
 		if err != nil {
+			if cerr := ctx.Err(); cerr != nil {
+				return &retry.PermFail{Err: cerr}
+			}
 			return err
 		}
 
@@ -735,8 +741,14 @@ func (d *Client) GetOverviews(ctx context.Context, uids ...UID) (emails map[UID]
 
 	var records [][]*Token
 	err = retry.Retry(func() (err error) {
+		if cerr := ctx.Err(); cerr != nil {
+			return &retry.PermFail{Err: cerr}
+		}
 		r, err := d.Exec(ctx, "UID FETCH "+uidsStr.String()+" ALL", true, 0, nil)
 		if err != nil {
+			if cerr := ctx.Err(); cerr != nil {
+				return &retry.PermFail{Err: cerr}
+			}
 			return err
 		}
 

--- a/message.go
+++ b/message.go
@@ -225,6 +225,17 @@ func (d *Client) GetMaxUID(ctx context.Context) (uid UID, err error) {
 	return parseMaxUIDSearchResponse(r)
 }
 
+// restoreReadOnly re-EXAMINEs the current folder to restore read-only mode
+// after a temporary SELECT. The caller's ctx cancellation is detached so a
+// cancelled or timed-out mutation cannot leave the client stuck in
+// read-write mode; cleanupContext bounds the EXAMINE so a stalled server
+// cannot hang the call.
+func (d *Client) restoreReadOnly(ctx context.Context) error {
+	restoreCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+	return d.ExamineFolder(restoreCtx, d.Folder)
+}
+
 // MoveEmail moves an email to a different folder.
 func (d *Client) MoveEmail(ctx context.Context, uid UID, folder string) (err error) {
 	// if we are currently read-only, switch to SELECT for the move-operation
@@ -234,7 +245,7 @@ func (d *Client) MoveEmail(ctx context.Context, uid UID, folder string) (err err
 	}
 	_, err = d.Exec(ctx, `UID MOVE `+uid.String()+` "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
 	if readOnlyState {
-		_ = d.ExamineFolder(ctx, d.Folder)
+		_ = d.restoreReadOnly(ctx)
 	}
 	if err != nil {
 		return err
@@ -255,7 +266,7 @@ func (d *Client) CopyEmail(ctx context.Context, uid UID, folder string) error {
 	}
 	_, err := d.Exec(ctx, `UID COPY `+uid.String()+` "`+AddSlashes.Replace(folder)+`"`, true, 0, nil)
 	if readOnlyState {
-		if e := d.ExamineFolder(ctx, d.Folder); e != nil && err == nil {
+		if e := d.restoreReadOnly(ctx); e != nil && err == nil {
 			err = e
 		}
 	}
@@ -274,7 +285,7 @@ func (d *Client) MarkSeen(ctx context.Context, uid UID) (err error) {
 	}
 	err = d.SetFlags(ctx, uid, flags)
 	if readOnlyState {
-		_ = d.ExamineFolder(ctx, d.Folder)
+		_ = d.restoreReadOnly(ctx)
 	}
 
 	return err
@@ -294,7 +305,7 @@ func (d *Client) DeleteEmail(ctx context.Context, uid UID) (err error) {
 	}
 	err = d.SetFlags(ctx, uid, flags)
 	if readOnlyState {
-		if e := d.ExamineFolder(ctx, d.Folder); e != nil && err == nil {
+		if e := d.restoreReadOnly(ctx); e != nil && err == nil {
 			err = e
 		}
 	}
@@ -312,7 +323,7 @@ func (d *Client) Expunge(ctx context.Context) (err error) {
 	}
 	_, err = d.Exec(ctx, "EXPUNGE", false, d.effectiveRetryCount(), nil)
 	if readOnlyState {
-		if e := d.ExamineFolder(ctx, d.Folder); e != nil && err == nil {
+		if e := d.restoreReadOnly(ctx); e != nil && err == nil {
 			err = e
 		}
 	}
@@ -366,7 +377,7 @@ func (d *Client) SetFlags(ctx context.Context, uid UID, flags Flags) (err error)
 	}
 	_, err = d.Exec(ctx, query, true, d.effectiveRetryCount(), nil)
 	if readOnlyState {
-		_ = d.ExamineFolder(ctx, d.Folder)
+		_ = d.restoreReadOnly(ctx)
 	}
 
 	return err

--- a/message.go
+++ b/message.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	retry "github.com/StirlingMarketingGroup/go-retry"
-	"github.com/davecgh/go-spew/spew"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/jhillyerd/enmime/v2"
 	"golang.org/x/net/html/charset"
@@ -106,7 +105,7 @@ func (e EmailAddresses) String() string {
 		}
 		if len(n) != 0 {
 			if strings.ContainsRune(n, ',') {
-				fmt.Fprintf(&emails, `"%s" <%s>`, AddSlashes.Replace(n), e)
+				fmt.Fprintf(&emails, `"%s" <%s>`, addSlashes.Replace(n), e)
 			} else {
 				fmt.Fprintf(&emails, `%s <%s>`, n, e)
 			}
@@ -243,7 +242,7 @@ func (d *Client) MoveEmail(ctx context.Context, uid UID, folder string) (err err
 	if readOnlyState {
 		_ = d.SelectFolder(ctx, d.Folder)
 	}
-	_, err = d.Exec(ctx, `UID MOVE `+uid.String()+` "`+AddSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
+	_, err = d.Exec(ctx, `UID MOVE `+uid.String()+` "`+addSlashes.Replace(folder)+`"`, true, d.effectiveRetryCount(), nil)
 	if readOnlyState {
 		_ = d.restoreReadOnly(ctx)
 	}
@@ -264,7 +263,7 @@ func (d *Client) CopyEmail(ctx context.Context, uid UID, folder string) error {
 			return err
 		}
 	}
-	_, err := d.Exec(ctx, `UID COPY `+uid.String()+` "`+AddSlashes.Replace(folder)+`"`, true, 0, nil)
+	_, err := d.Exec(ctx, `UID COPY `+uid.String()+` "`+addSlashes.Replace(folder)+`"`, true, 0, nil)
 	if readOnlyState {
 		if e := d.restoreReadOnly(ctx); e != nil && err == nil {
 			err = e
@@ -390,9 +389,8 @@ func (d *Client) parseEmailBody(e *Email, bodyStr string) bool {
 	env, err := enmime.ReadEnvelope(r)
 	if err != nil {
 		if Verbose {
-			warnLog(d.ConnNum, d.Folder, "email body could not be parsed", "error", err)
-			spew.Dump(env)
-			spew.Dump(bodyStr)
+			warnLog(d.ConnNum, d.Folder, "email body could not be parsed",
+				"error", err, "envelope", fmt.Sprintf("%+v", env), "body", bodyStr)
 		}
 		return false
 	}

--- a/message_coverage_test.go
+++ b/message_coverage_test.go
@@ -1,0 +1,361 @@
+package imap
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestEmailString(t *testing.T) {
+	e := Email{
+		Subject: "Hi",
+		From:    EmailAddresses{"a@b.com": "Alice"},
+		To:      EmailAddresses{"c@d.com": "Bob"},
+		CC:      EmailAddresses{"cc@e.com": ""},
+		BCC:     EmailAddresses{"bcc@e.com": "Eve, Commander"},
+		ReplyTo: EmailAddresses{"r@e.com": ""},
+		Text:    strings.Repeat("x", 100),
+		HTML:    "short html",
+		Attachments: []Attachment{
+			{Name: "file.txt", MimeType: "text/plain", Content: []byte("abc")},
+		},
+	}
+	s := e.String()
+	for _, want := range []string{"Subject: Hi", "To:", "From:", "CC:", "BCC:", "ReplyTo:", "Text:", "HTML:", "Attachment"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("Email.String missing %q: %s", want, s)
+		}
+	}
+}
+
+func TestEmailAddressesString(t *testing.T) {
+	e := EmailAddresses{"a@b.com": "Alice"}
+	if got := e.String(); !strings.Contains(got, "a@b.com") || !strings.Contains(got, "Alice") {
+		t.Errorf("EmailAddresses.String: %q", got)
+	}
+	// With comma in name, should be quoted
+	e2 := EmailAddresses{"c@d.com": "Doe, John"}
+	if got := e2.String(); !strings.Contains(got, `"Doe, John"`) {
+		t.Errorf("comma-name not quoted: %q", got)
+	}
+	// No name -> bare email
+	e3 := EmailAddresses{"only@b.com": ""}
+	if got := e3.String(); got != "only@b.com" {
+		t.Errorf("bare: %q", got)
+	}
+}
+
+func TestAttachmentString(t *testing.T) {
+	a := Attachment{Name: "f.pdf", MimeType: "application/pdf", Content: []byte("hi")}
+	s := a.String()
+	if !strings.Contains(s, "f.pdf") || !strings.Contains(s, "application/pdf") {
+		t.Errorf("Attachment.String: %q", s)
+	}
+}
+
+func TestGetUIDs(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		if strings.HasPrefix(strings.ToUpper(line), tag+" UID SEARCH") {
+			w.WriteString("* SEARCH 1 3 5 7\r\n")
+			w.WriteString(tag + " OK SEARCH completed\r\n")
+			return true
+		}
+		return false
+	}
+	uids, err := d.GetUIDs(context.Background(), "ALL")
+	if err != nil {
+		t.Fatalf("GetUIDs: %v", err)
+	}
+	want := []UID{1, 3, 5, 7}
+	if len(uids) != len(want) {
+		t.Fatalf("want %v, got %v", want, uids)
+	}
+	for i, u := range uids {
+		if u != want[i] {
+			t.Errorf("uid[%d]: want %d got %d", i, want[i], u)
+		}
+	}
+}
+
+func TestGetUIDsError(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.failCommands = map[string]bool{"UID": true}
+	_, err := d.GetUIDs(context.Background(), "ALL")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetLastNUIDs(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		if strings.HasPrefix(strings.ToUpper(line), tag+" UID SEARCH") {
+			w.WriteString("* SEARCH 1 2 3 4 5 6 7 8 9 10\r\n")
+			w.WriteString(tag + " OK SEARCH completed\r\n")
+			return true
+		}
+		return false
+	}
+	uids, err := d.GetLastNUIDs(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("GetLastNUIDs: %v", err)
+	}
+	if len(uids) != 3 || uids[0] != 8 || uids[2] != 10 {
+		t.Errorf("want [8,9,10], got %v", uids)
+	}
+
+	// n <= 0 returns nil
+	uids, err = d.GetLastNUIDs(context.Background(), 0)
+	if err != nil || uids != nil {
+		t.Errorf("n=0: want nil,nil, got %v,%v", uids, err)
+	}
+
+	// n > total returns all
+	uids, err = d.GetLastNUIDs(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("GetLastNUIDs: %v", err)
+	}
+	if len(uids) != 10 {
+		t.Errorf("n>total: want 10, got %d", len(uids))
+	}
+}
+
+func TestGetLastNUIDsError(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.failCommands = map[string]bool{"UID": true}
+	_, err := d.GetLastNUIDs(context.Background(), 5)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetMaxUID(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		if strings.HasPrefix(strings.ToUpper(line), tag+" UID SEARCH RETURN (MAX)") {
+			w.WriteString(`* ESEARCH (TAG "` + tag + `") UID MAX 42` + "\r\n")
+			w.WriteString(tag + " OK SEARCH completed\r\n")
+			return true
+		}
+		return false
+	}
+	max, err := d.GetMaxUID(context.Background())
+	if err != nil {
+		t.Fatalf("GetMaxUID: %v", err)
+	}
+	if max != 42 {
+		t.Errorf("want 42, got %d", max)
+	}
+}
+
+func TestGetMaxUIDError(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.failCommands = map[string]bool{"UID": true}
+	_, err := d.GetMaxUID(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// mutationHandler responds to SELECT, UID STORE/MOVE/COPY, EXPUNGE, EXAMINE.
+func mutationHandler() func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+	return func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, tag+" SELECT ") || strings.HasPrefix(upper, tag+" EXAMINE "):
+			w.WriteString("* 0 EXISTS\r\n* 0 RECENT\r\n")
+			w.WriteString(tag + " OK [READ-WRITE] completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" UID STORE"):
+			w.WriteString(tag + " OK STORE completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" UID MOVE"):
+			w.WriteString(tag + " OK MOVE completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" UID COPY"):
+			w.WriteString(tag + " OK COPY completed\r\n")
+			return true
+		case strings.HasPrefix(upper, tag+" EXPUNGE"):
+			w.WriteString(tag + " OK EXPUNGE completed\r\n")
+			return true
+		}
+		return false
+	}
+}
+
+func TestSetFlags(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = mutationHandler()
+	if err := d.SelectFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("SelectFolder: %v", err)
+	}
+	err := d.SetFlags(context.Background(), 42, Flags{
+		Seen:    FlagAdd,
+		Deleted: FlagRemove,
+		Keywords: map[string]bool{
+			"$Important": true,
+			"$Archived":  false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetFlags: %v", err)
+	}
+}
+
+func TestMarkSeen(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = mutationHandler()
+	if err := d.ExamineFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("ExamineFolder: %v", err)
+	}
+	if err := d.MarkSeen(context.Background(), 7); err != nil {
+		t.Fatalf("MarkSeen: %v", err)
+	}
+	// Should be back in read-only after restore
+	if !d.ReadOnly {
+		t.Error("expected ReadOnly after MarkSeen from EXAMINE mode")
+	}
+}
+
+func TestDeleteEmail(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = mutationHandler()
+	if err := d.SelectFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("SelectFolder: %v", err)
+	}
+	if err := d.DeleteEmail(context.Background(), 7); err != nil {
+		t.Fatalf("DeleteEmail: %v", err)
+	}
+}
+
+func TestMoveEmail(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = mutationHandler()
+	if err := d.SelectFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("SelectFolder: %v", err)
+	}
+	if err := d.MoveEmail(context.Background(), 7, "Archive"); err != nil {
+		t.Fatalf("MoveEmail: %v", err)
+	}
+	if d.Folder != "Archive" {
+		t.Errorf("expected Folder=Archive, got %q", d.Folder)
+	}
+}
+
+func TestMoveEmailFromReadOnly(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = mutationHandler()
+	if err := d.ExamineFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("ExamineFolder: %v", err)
+	}
+	if err := d.MoveEmail(context.Background(), 7, "Archive"); err != nil {
+		t.Fatalf("MoveEmail: %v", err)
+	}
+}
+
+func TestExpunge(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = mutationHandler()
+	if err := d.SelectFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("SelectFolder: %v", err)
+	}
+	if err := d.Expunge(context.Background()); err != nil {
+		t.Fatalf("Expunge: %v", err)
+	}
+}
+
+func TestExpungeFromReadOnly(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = mutationHandler()
+	if err := d.ExamineFolder(context.Background(), "INBOX"); err != nil {
+		t.Fatalf("ExamineFolder: %v", err)
+	}
+	if err := d.Expunge(context.Background()); err != nil {
+		t.Fatalf("Expunge from RO: %v", err)
+	}
+}
+
+// TestGetOverviews_Empty verifies an empty UID FETCH response produces an empty map.
+func TestGetOverviews_Empty(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		if strings.HasPrefix(strings.ToUpper(line), tag+" UID FETCH") {
+			// No untagged data, just OK
+			w.WriteString(tag + " OK FETCH completed\r\n")
+			return true
+		}
+		return false
+	}
+	emails, err := d.GetOverviews(context.Background())
+	if err != nil {
+		t.Fatalf("GetOverviews: %v", err)
+	}
+	if len(emails) != 0 {
+		t.Errorf("want empty map, got %d", len(emails))
+	}
+}
+
+// TestGetEmails_Empty exercises the GetEmails entrypoint when the overview
+// fetch returns no rows — the short-circuit path avoids issuing UID FETCH BODY.
+func TestGetEmails_Empty(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		if strings.HasPrefix(strings.ToUpper(line), tag+" UID FETCH") {
+			w.WriteString(tag + " OK FETCH completed\r\n")
+			return true
+		}
+		return false
+	}
+	emails, err := d.GetEmails(context.Background())
+	if err != nil {
+		t.Fatalf("GetEmails: %v", err)
+	}
+	if len(emails) != 0 {
+		t.Errorf("want empty map, got %d", len(emails))
+	}
+}
+
+func TestGetEmailsWithSpecificUIDs_Empty(t *testing.T) {
+	d, srv := withMockClient(t)
+	srv.handler = func(tag, line string, r *bufio.Reader, w *bufio.Writer) bool {
+		if strings.HasPrefix(strings.ToUpper(line), tag+" UID FETCH") {
+			w.WriteString(tag + " OK FETCH completed\r\n")
+			return true
+		}
+		return false
+	}
+	emails, err := d.GetEmails(context.Background(), 1, 2, 3)
+	if err != nil {
+		t.Fatalf("GetEmails: %v", err)
+	}
+	if len(emails) != 0 {
+		t.Errorf("want empty map, got %d", len(emails))
+	}
+}
+
+func TestUIDAndMessageSeqString(t *testing.T) {
+	if got := UID(0).String(); got != "0" {
+		t.Errorf("UID(0): %q", got)
+	}
+	if got := UID(4294967295).String(); got != "4294967295" {
+		t.Errorf("UID max: %q", got)
+	}
+	if got := MessageSeq(7).String(); got != "7" {
+		t.Errorf("MessageSeq(7): %q", got)
+	}
+}
+
+func TestUIDFromToken(t *testing.T) {
+	u, err := uidFromToken(42)
+	if err != nil || u != 42 {
+		t.Errorf("valid uid: got %d, %v", u, err)
+	}
+	if _, err := uidFromToken(-1); err == nil {
+		t.Error("expected error for negative UID")
+	}
+	if _, err := uidFromToken(1 << 33); err == nil {
+		t.Error("expected error for oversized UID")
+	}
+}

--- a/message_test.go
+++ b/message_test.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
+
 func parseRecords(d *Dialer, records [][]*Token) (map[int]*Email, error) {
 	emails := make(map[int]*Email, len(records))
 	CharsetReader := func(label string, input io.Reader) (io.Reader, error) {
@@ -101,7 +102,7 @@ func TestGetLastNUIDs_EdgeCases(t *testing.T) {
 
 	t.Run("n=0 returns nil", func(t *testing.T) {
 		t.Parallel()
-		result, err := d.GetLastNUIDs(0)
+		result, err := d.GetLastNUIDs(ctx, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -112,7 +113,7 @@ func TestGetLastNUIDs_EdgeCases(t *testing.T) {
 
 	t.Run("n=-1 returns nil", func(t *testing.T) {
 		t.Parallel()
-		result, err := d.GetLastNUIDs(-1)
+		result, err := d.GetLastNUIDs(ctx, -1)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -123,7 +124,7 @@ func TestGetLastNUIDs_EdgeCases(t *testing.T) {
 
 	t.Run("n=-100 returns nil", func(t *testing.T) {
 		t.Parallel()
-		result, err := d.GetLastNUIDs(-100)
+		result, err := d.GetLastNUIDs(ctx, -100)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 
-func parseRecords(d *Dialer, records [][]*Token) (map[int]*Email, error) {
-	emails := make(map[int]*Email, len(records))
+func parseRecords(d *Dialer, records [][]*Token) (map[UID]*Email, error) {
+	emails := make(map[UID]*Email, len(records))
 	CharsetReader := func(label string, input io.Reader) (io.Reader, error) {
 		label = strings.Replace(label, "windows-", "cp", -1)
 		encoding, _ := charset.Lookup(label)
@@ -84,7 +84,11 @@ func parseRecords(d *Dialer, records [][]*Token) (map[int]*Email, error) {
 				if err := d.CheckType(tks[i+1], []TType{TNumber}, tks, "after UID"); err != nil {
 					return nil, err
 				}
-				e.UID = tks[i+1].Num
+				u, err := uidFromToken(tks[i+1].Num)
+				if err != nil {
+					return nil, err
+				}
+				e.UID = u
 				skip++
 			}
 		}

--- a/mock_helpers_test.go
+++ b/mock_helpers_test.go
@@ -1,0 +1,60 @@
+package imap
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"testing"
+)
+
+// withMockClient starts a mock IMAP server, dials it with valid credentials,
+// and returns the connected client plus the mock server. Both are closed
+// automatically when the test completes.
+func withMockClient(t *testing.T) (*Client, *mockIMAPServer) {
+	t.Helper()
+
+	originalVerbose := Verbose
+	originalRetry := RetryCount
+	originalSkip := TLSSkipVerify
+	Verbose = false
+	RetryCount = 0
+	TLSSkipVerify = true
+	t.Cleanup(func() {
+		Verbose = originalVerbose
+		RetryCount = originalRetry
+		TLSSkipVerify = originalSkip
+	})
+
+	srv, err := newMockIMAPServer("u", "p")
+	if err != nil {
+		t.Fatalf("newMockIMAPServer: %v", err)
+	}
+	t.Cleanup(func() { srv.Close() })
+
+	d, err := Dial(context.Background(), Options{
+		Host: srv.GetHost(),
+		Port: srv.GetPort(),
+		Auth: PasswordAuth{Username: "u", Password: "p"},
+	})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	return d, srv
+}
+
+// respond is a tiny helper for mock handlers that writes untagged data
+// followed by a tagged OK line. Both arguments may be empty.
+func respond(w *bufio.Writer, tag, untagged, okMessage string) {
+	if untagged != "" {
+		if !strings.HasSuffix(untagged, "\r\n") {
+			untagged += "\r\n"
+		}
+		w.WriteString(untagged)
+	}
+	if okMessage == "" {
+		okMessage = "completed"
+	}
+	w.WriteString(tag + " OK " + okMessage + "\r\n")
+}

--- a/options.go
+++ b/options.go
@@ -3,7 +3,6 @@ package imap
 import (
 	"context"
 	"crypto/tls"
-	"log/slog"
 	"net"
 	"time"
 )
@@ -51,10 +50,6 @@ type Options struct {
 	// Dialer overrides the default *net.Dialer used to establish the TCP
 	// connection. Useful for SOCKS proxies or custom network setups.
 	Dialer ContextDialer
-
-	// Logger is the slog logger used for all library output. When nil, the
-	// package-level logger is used (see SetSlogLogger).
-	Logger *slog.Logger
 }
 
 // Authenticator performs IMAP authentication after the TLS connection is

--- a/options.go
+++ b/options.go
@@ -1,0 +1,84 @@
+package imap
+
+import (
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"net"
+	"time"
+)
+
+// ContextDialer matches net.Dialer.DialContext and allows injecting a custom
+// dialer (e.g. SOCKS proxy).
+type ContextDialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Options configures a new Client. The zero value is not usable — Host and
+// Auth are required. Everything else has a sensible default.
+type Options struct {
+	// Host is the IMAP server hostname. Required.
+	Host string
+
+	// Port is the IMAP server port. Defaults to 993 (IMAPS).
+	Port int
+
+	// Auth is the authentication method. Required.
+	Auth Authenticator
+
+	// DialTimeout bounds how long Dial waits to establish the TCP/TLS
+	// connection. Zero means no timeout.
+	DialTimeout time.Duration
+
+	// CommandTimeout is the per-command deadline.
+	//   positive: use this duration for every command
+	//   zero:     fall back to the package-level CommandTimeout
+	//   negative: explicitly disable the deadline for this client
+	CommandTimeout time.Duration
+
+	// RetryCount is the number of times to retry a failed command.
+	//   positive: retry up to this many times
+	//   zero:     fall back to the package-level RetryCount
+	//   negative: explicitly disable retries for this client
+	RetryCount int
+
+	// TLSConfig overrides the default TLS configuration. When nil, a secure
+	// default is used. Dial will set ServerName to Host if ServerName is
+	// empty so that hostname verification works out of the box. The caller's
+	// config is not mutated.
+	TLSConfig *tls.Config
+
+	// Dialer overrides the default *net.Dialer used to establish the TCP
+	// connection. Useful for SOCKS proxies or custom network setups.
+	Dialer ContextDialer
+
+	// Logger is the slog logger used for all library output. When nil, the
+	// package-level logger is used (see SetSlogLogger).
+	Logger *slog.Logger
+}
+
+// Authenticator performs IMAP authentication after the TLS connection is
+// established.
+type Authenticator interface {
+	authenticate(ctx context.Context, c *Client) error
+}
+
+// PasswordAuth authenticates using the IMAP LOGIN command.
+type PasswordAuth struct {
+	Username string
+	Password string
+}
+
+func (a PasswordAuth) authenticate(ctx context.Context, c *Client) error {
+	return c.Login(ctx, a.Username, a.Password)
+}
+
+// XOAuth2 authenticates using the XOAUTH2 SASL mechanism.
+type XOAuth2 struct {
+	Username    string
+	AccessToken string
+}
+
+func (a XOAuth2) authenticate(ctx context.Context, c *Client) error {
+	return c.Authenticate(ctx, a.Username, a.AccessToken)
+}

--- a/parse.go
+++ b/parse.go
@@ -20,11 +20,13 @@ var (
 	searchMaxUIDRE   = regexp.MustCompile(`(?i)\* ESEARCH .* MAX (\d+)`)
 )
 
-// Token represents a parsed IMAP token
+// Token represents a parsed IMAP token. Num is int64 so that any RFC-allowed
+// 32-bit unsigned IMAP number (UID, sequence number) parses losslessly even
+// on 32-bit builds, and so that RFC822.SIZE values can fit without truncation.
 type Token struct {
 	Type   TType
 	Str    string
-	Num    int
+	Num    int64
 	Tokens []*Token
 }
 
@@ -65,7 +67,7 @@ func makeFetchToken(tokenType TType, r string, tokenStart, tokenEnd int) *Token 
 		return &Token{Type: tokenType, Str: RemoveSlashes.Replace(string(r[tokenStart : tokenEnd+1]))}
 	case TLiteral:
 		s := string(r[tokenStart : tokenEnd+1])
-		num, err := strconv.Atoi(s)
+		num, err := strconv.ParseInt(s, 10, 64)
 		if err == nil {
 			return &Token{Type: TNumber, Num: num}
 		}
@@ -419,7 +421,7 @@ func extractFetchContent(body string, start int) (fetchContentStart, fetchConten
 	}
 
 	seqNumStr := rest[:idx]
-	if _, convErr := strconv.Atoi(seqNumStr); convErr != nil {
+	if _, convErr := strconv.ParseUint(seqNumStr, 10, 32); convErr != nil {
 		return 0, 0, fmt.Errorf("unable to parse Fetch line (invalid seq num %s): %#v: %w", seqNumStr, lineSnippet(), convErr)
 	}
 
@@ -485,7 +487,7 @@ func (d *Client) ParseFetchResponse(responseBody string) (records [][]*Token, er
 }
 
 // parseUIDSearchResponse parses UID SEARCH command responses
-func parseUIDSearchResponse(r string) ([]int, error) {
+func parseUIDSearchResponse(r string) ([]UID, error) {
 	normalized := strings.ReplaceAll(r, nl, "\n")
 	for rawLine := range strings.SplitSeq(normalized, "\n") {
 		line := strings.TrimSpace(rawLine)
@@ -498,13 +500,13 @@ func parseUIDSearchResponse(r string) ([]int, error) {
 			continue
 		}
 
-		uids := make([]int, 0, len(fields)-2)
+		uids := make([]UID, 0, len(fields)-2)
 		for _, f := range fields[2:] {
-			u, err := strconv.Atoi(f)
+			u, err := strconv.ParseUint(f, 10, 32)
 			if err != nil {
 				return nil, fmt.Errorf("parse uid %q: %w", f, err)
 			}
-			uids = append(uids, u)
+			uids = append(uids, UID(u))
 		}
 		return uids, nil
 	}
@@ -526,7 +528,7 @@ func parseUIDSearchResponse(r string) ([]int, error) {
 //
 // In that case this function returns 0, nil.
 // ref https://www.rfc-editor.org/rfc/rfc4731.html#page-2
-func parseMaxUIDSearchResponse(r string) (int, error) {
+func parseMaxUIDSearchResponse(r string) (UID, error) {
 	normalized := strings.ReplaceAll(r, nl, "\n")
 	for rawLine := range strings.SplitSeq(normalized, "\n") {
 		line := strings.TrimSpace(rawLine)
@@ -535,11 +537,11 @@ func parseMaxUIDSearchResponse(r string) (int, error) {
 		}
 
 		if matches := searchMaxUIDRE.FindStringSubmatch(line); len(matches) > 1 {
-			maxUID, err := strconv.Atoi(matches[1])
+			maxUID, err := strconv.ParseUint(matches[1], 10, 32)
 			if err != nil {
 				return 0, fmt.Errorf("parse max uid %q: %w", matches[1], err)
 			}
-			return maxUID, nil
+			return UID(maxUID), nil
 		}
 
 		// Check for ESEARCH line without a valid MAX capture

--- a/parse.go
+++ b/parse.go
@@ -439,7 +439,7 @@ func extractFetchContent(body string, start int) (fetchContentStart, fetchConten
 }
 
 // ParseFetchResponse parses a multi-line FETCH response
-func (d *Dialer) ParseFetchResponse(responseBody string) (records [][]*Token, err error) {
+func (d *Client) ParseFetchResponse(responseBody string) (records [][]*Token, err error) {
 	records = make([][]*Token, 0)
 	trimmedResponseBody := strings.TrimSpace(responseBody)
 	if trimmedResponseBody == "" {
@@ -618,7 +618,7 @@ func (t Token) String() string {
 }
 
 // CheckType validates that a token is one of the acceptable types
-func (d *Dialer) CheckType(token *Token, acceptableTypes []TType, tks []*Token, loc string, v ...any) (err error) {
+func (d *Client) CheckType(token *Token, acceptableTypes []TType, tks []*Token, loc string, v ...any) (err error) {
 	if slices.Contains(acceptableTypes, token.Type) {
 		return nil
 	}

--- a/parse.go
+++ b/parse.go
@@ -64,7 +64,7 @@ func calculateTokenEnd(tokenStart, sizeVal, bufferLen int) (int, error) {
 func makeFetchToken(tokenType TType, r string, tokenStart, tokenEnd int) *Token {
 	switch tokenType {
 	case TQuoted:
-		return &Token{Type: tokenType, Str: RemoveSlashes.Replace(string(r[tokenStart : tokenEnd+1]))}
+		return &Token{Type: tokenType, Str: removeSlashes.Replace(string(r[tokenStart : tokenEnd+1]))}
 	case TLiteral:
 		s := string(r[tokenStart : tokenEnd+1])
 		num, err := strconv.ParseInt(s, 10, 64)

--- a/parse_test.go
+++ b/parse_test.go
@@ -215,13 +215,13 @@ func TestParseUIDSearchResponse(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		want    []int
+		want    []UID
 		wantErr bool
 	}{
 		{
 			name:  "basic search response",
 			input: "* SEARCH 123 456\r\nA1 OK SEARCH completed\r\n",
-			want:  []int{123, 456},
+			want:  []UID{123, 456},
 		},
 		{
 			name: "literal preamble is ignored",
@@ -230,7 +230,7 @@ func TestParseUIDSearchResponse(t *testing.T) {
 				"* SEARCH 15461 15469 15470 15485 15491 15497",
 				"A144 OK UID SEARCH completed",
 			}, "\r\n"),
-			want: []int{15461, 15469, 15470, 15485, 15491, 15497},
+			want: []UID{15461, 15469, 15470, 15485, 15491, 15497},
 		},
 		{
 			name:    "no search line",

--- a/search.go
+++ b/search.go
@@ -53,7 +53,7 @@ func (s *SearchBuilder) buildRaw() string {
 // Example:
 //
 //	uids, err := conn.SearchUIDs(ctx, imap.Search().From("alice@example.com").Unseen())
-func (d *Client) SearchUIDs(ctx context.Context, search *SearchBuilder) ([]int, error) {
+func (d *Client) SearchUIDs(ctx context.Context, search *SearchBuilder) ([]UID, error) {
 	return d.GetUIDs(ctx, search.Build())
 }
 

--- a/search.go
+++ b/search.go
@@ -1,6 +1,7 @@
 package imap
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -51,9 +52,9 @@ func (s *SearchBuilder) buildRaw() string {
 //
 // Example:
 //
-//	uids, err := conn.SearchUIDs(imap.Search().From("alice@example.com").Unseen())
-func (d *Dialer) SearchUIDs(search *SearchBuilder) ([]int, error) {
-	return d.GetUIDs(search.Build())
+//	uids, err := conn.SearchUIDs(ctx, imap.Search().From("alice@example.com").Unseen())
+func (d *Client) SearchUIDs(ctx context.Context, search *SearchBuilder) ([]int, error) {
+	return d.GetUIDs(ctx, search.Build())
 }
 
 // --- Flag criteria ---

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -1,0 +1,7 @@
+package imap
+
+import "context"
+
+// ctx is the default context used by tests. Tests that need cancellation or
+// timeouts should construct their own context inline.
+var ctx = context.Background()

--- a/vars.go
+++ b/vars.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-// String replacers for escaping/unescaping quotes
+// String replacers for escaping/unescaping quotes in IMAP strings.
 var (
-	AddSlashes    = strings.NewReplacer(`"`, `\"`)
-	RemoveSlashes = strings.NewReplacer(`\"`, `"`)
+	addSlashes    = strings.NewReplacer(`"`, `\"`)
+	removeSlashes = strings.NewReplacer(`\"`, `"`)
 )
 
 // Verbose outputs every command and its response with the IMAP server
@@ -31,5 +31,3 @@ var CommandTimeout time.Duration
 // connections. Use with caution; skipping verification exposes the
 // connection to man-in-the-middle attacks.
 var TLSSkipVerify bool
-
-var lastResp string


### PR DESCRIPTION
## Summary

v1.0.0 API overhaul — six focused breaking-change phases. This is the long-planned cleanup before tagging v1.

- **Phase 1** — Introduce `Options`/`Dial`/`Client`; require `context.Context` everywhere. `New`/`NewWithOAuth2`/`Dialer` kept as deprecated aliases until v2.
- **Phase 2** — Context plumbed through every method; retry loops honor cancellation.
- **Phase 3** — Typed `UID` and `MessageSeq` (replacing plain `int`), with RFC-3501 32-bit range validation.
- **Phase 4** — Collapse folder-count API into `TotalEmailCount`/`FolderStats` with `CountOptions`; add folder CRUD (`CreateFolder`, `DeleteFolder`, `RenameFolder`), `CopyEmail`, `SearchBuilder`, and `Append`.
- **Phase 5** — Typed `*CommandError` (`Tag`/`Status`/`Code`/`Text`/`Command`) + `ErrAuthFailed`/`ErrFolderNotFound` sentinels (narrowed to RFC 5530 `[AUTHENTICATIONFAILED]`/`[NONEXISTENT]` codes only, not bare NO).
- **Phase 6** — Introduce `type State int` with `String()`; unexport internal quote helpers; drop `go-spew`; fix Clone/Reconnect/IDLE-startup socket & goroutine leaks.

Each phase went through 2–7 rounds of Codex GPT-5.4 review with fixes applied before moving on.

## Notable behavioral fixes found along the way

- `Append` misparsing tagged `NO`/`BAD`/`BYE` returned before the `+` continuation (e.g. `[TRYCREATE]`, `[OVERQUOTA]`).
- `Append` reporting a committed message as `context.Canceled`, which would cause duplicate mail on retry.
- Pointer-authenticator (`*PasswordAuth`, `*XOAuth2`) credentials leaking in verbose logs because `credsFromAuth` only matched value types.
- `GetEmails`/`GetOverviews` outer retry loops swallowing `ctx.Err()` and reconnecting on cancellation.
- IDLE 5s startup-timeout leaking the detached `Exec` goroutine and leaving the client in an indeterminate state.
- `Clone` and `Reconnect` leaking newly-established sockets if post-dial folder re-selection failed.
- `Clone`/`Reconnect` using `%s` instead of `%w` so `errors.Is`/`As` couldn't traverse.

## Scope

34 files changed, +1677/-953. Also updates all 10 example programs and the README to the new API.

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [x] All examples build
- [ ] Manual smoke test against real IMAP server (Gmail + Dovecot) before tagging v1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)